### PR TITLE
Refactor App state handling into focused hooks

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,11 +18,9 @@ import {
 } from "./features/project-shell/projectShellConstants";
 import type { LabelDraft, PendingAction, RightTab, SelectionPreview } from "./features/project-shell/projectShellTypes";
 import {
-  collectDocumentNames,
   createEmptyLabelDraft,
   findConflictingLabelName,
   isHexColor,
-  mergeDocumentWindow,
   normalizeHexColor,
   toLabelDraft,
   toDocumentListItem,
@@ -32,15 +30,13 @@ import { ShortcutPopover } from "./features/project-shell/ShortcutPopover";
 import { useBodyScrollLock } from "./features/project-shell/useBodyScrollLock";
 import { useProjectExamples } from "./features/project-shell/useProjectExamples";
 import { useProjectShortcuts } from "./features/project-shell/useProjectShortcuts";
+import { useDocumentHistory } from "./features/project-shell/useDocumentHistory";
+import { useImportExport } from "./features/project-shell/useImportExport";
+import { useProjectBundle } from "./features/project-shell/useProjectBundle";
 import { sortAnnotationsInPanelOrder } from "./features/workspace/workspaceUtils";
 import { WorkspaceView } from "./features/project-shell/WorkspaceView";
 import { useAuthSession } from "./hooks/useAuthSession";
 import { useToast } from "./hooks/useToast";
-import {
-  buildImportValidationMessage,
-  describeImportSummary,
-  validateImportPayload,
-} from "./importValidation";
 import { LoginPage } from "./pages/LoginPage";
 import { ProjectsPage } from "./pages/ProjectsPage";
 import type {
@@ -51,16 +47,13 @@ import type {
   UserRecord,
 } from "./types";
 import {
-  buildExportFilename,
   deepClone,
   documentMatchesSearch,
-  downloadJson,
   formatAnnotationMetaDraft,
   getDocumentStatus,
   isLocalId,
   makeLocalId,
   parseAnnotationMetaDraft,
-  readJsonFile,
   setProjectGuideline,
 } from "./utils";
 
@@ -78,18 +71,6 @@ export function ProjectShell({
   const { projectId = "" } = useParams();
   const view: "workspace" | "settings" = location.pathname.endsWith("/settings") ? "settings" : "workspace";
   const { toast, showToast, closeToast } = useToast();
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [bundle, setBundle] = useState<ProjectBundle | null>(null);
-  const [settingsSnapshot, setSettingsSnapshot] = useState<Pick<ProjectBundle, "project" | "labels"> | null>(null);
-  const [documentSnapshotsById, setDocumentSnapshotsById] = useState<Record<string, DocumentRecord>>({});
-  const [historyState, setHistoryState] = useState<{ documentId: string | null; entries: DocumentRecord[]; index: number }>({
-    documentId: null,
-    entries: [],
-    index: -1,
-  });
-  const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
-  const [focusedLabelId, setFocusedLabelId] = useState<string | null>(null);
   const [selectedSettingsLabelId, setSelectedSettingsLabelId] = useState<string | null>(null);
   const [selectedAnnotationId, setSelectedAnnotationId] = useState<string | null>(null);
   const [selectedAnnotationMetaDraft, setSelectedAnnotationMetaDraft] = useState("");
@@ -98,30 +79,15 @@ export function ProjectShell({
   const [rightTab, setRightTab] = useState<RightTab>("examples");
   const [annotationEditCollapsed, setAnnotationEditCollapsed] = useState(true);
   const [accordionOpen, setAccordionOpen] = useState<Record<string, boolean>>({});
-  const [searchQuery, setSearchQuery] = useState("");
-  const [sortMode, setSortMode] = useState("created");
   const [shortcutOpen, setShortcutOpen] = useState(false);
-  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
   const [createDocOpen, setCreateDocOpen] = useState(false);
   const [newDocName, setNewDocName] = useState("");
   const [newDocText, setNewDocText] = useState("");
   const [labelDraft, setLabelDraft] = useState<LabelDraft>(createEmptyLabelDraft);
-  const [settingsImportFile, setSettingsImportFile] = useState<File | null>(null);
-  const [settingsImportFeedback, setSettingsImportFeedback] = useState<{
-    severity: "success" | "info" | "warning" | "error";
-    message: string;
-  } | null>(null);
-  const [settingsImporting, setSettingsImporting] = useState(false);
-  const [exportPending, setExportPending] = useState(true);
-  const [exportVerified, setExportVerified] = useState(true);
-  const [documentList, setDocumentList] = useState<DocumentListItem[]>([]);
-  const [documentTotal, setDocumentTotal] = useState(0);
-  const [pendingDocumentTotal, setPendingDocumentTotal] = useState(0);
-  const [documentNextOffset, setDocumentNextOffset] = useState(0);
-  const [documentsLoadingMore, setDocumentsLoadingMore] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; documentName: string; isCurrent: boolean } | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deletingDocument, setDeletingDocument] = useState(false);
+  const [creatingDocument, setCreatingDocument] = useState(false);
   const shortcutButtonRef = useRef<HTMLButtonElement | null>(null);
   const pendingActionConfirmButtonRef = useRef<HTMLButtonElement | null>(null);
   const deleteDocumentConfirmButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -130,177 +96,147 @@ export function ProjectShell({
   const sameSurfaceExamplesScrollRef = useRef<HTMLDivElement | null>(null);
   const shortcutDragStateRef = useRef<{ startX: number; startY: number; originX: number; originY: number } | null>(null);
   const labelColorInputRef = useRef<HTMLInputElement | null>(null);
-  const documentListRequestIdRef = useRef(0);
   const [shortcutPanelOffset, setShortcutPanelOffset] = useState({ x: 0, y: 0 });
   const [shortcutDragging, setShortcutDragging] = useState(false);
-  const initialDocumentListLoadedRef = useRef(false);
+  const {
+    loading,
+    bundle,
+    setBundle,
+    settingsSnapshot,
+    setSettingsSnapshot,
+    selectedDocId,
+    setSelectedDocId,
+    focusedLabelId,
+    setFocusedLabelId,
+    searchQuery,
+    setSearchQuery,
+    sortMode,
+    setSortMode,
+    documentList,
+    setDocumentList,
+    documentTotal,
+    setDocumentTotal,
+    pendingDocumentTotal,
+    setPendingDocumentTotal,
+    documentNextOffset,
+    setDocumentNextOffset,
+    documentsLoadingMore,
+    setDocumentsLoadingMore,
+    currentDocument,
+    currentDocumentLoading,
+    loadBundle,
+    fetchDocumentPage,
+  } = useProjectBundle({
+    token,
+    projectId,
+    showToast,
+    onBundleLoaded: ({ bundle }) => {
+      setSelectedSettingsLabelId(null);
+      setLabelDraft(createEmptyLabelDraft);
+      setFocusedLabelId(bundle.labels[0]?.id ?? null);
+      setAccordionOpen(Object.fromEntries(bundle.labels.map((label) => [label.id, true])));
+    },
+  });
+
+  const {
+    documentSnapshotsById,
+    setDocumentSnapshotsById,
+    historyState,
+    currentDocumentSnapshot,
+    currentDocumentDirty,
+    canUndo,
+    canRedo,
+    setHistoryForDocument,
+    setSavedDocument,
+    removeDocumentState,
+    mutateCurrentDocument,
+    mutateSettingsBundle,
+    undo,
+    redo,
+    restoreCurrentFromSnapshot,
+  } = useDocumentHistory({
+    bundle,
+    currentDocument,
+    setBundle,
+  });
+
+  const settingsDirty = useMemo(() => {
+    if (!bundle || !settingsSnapshot) {
+      return false;
+    }
+    return (
+      JSON.stringify(bundle.project) !== JSON.stringify(settingsSnapshot.project) ||
+      JSON.stringify(bundle.labels) !== JSON.stringify(settingsSnapshot.labels)
+    );
+  }, [bundle, settingsSnapshot]);
+
+  const {
+    saving,
+    pendingAction,
+    setPendingAction,
+    settingsImportFile,
+    setSettingsImportFile,
+    settingsImportFeedback,
+    settingsImporting,
+    exportPending,
+    setExportPending,
+    exportVerified,
+    setExportVerified,
+    requestAction,
+    resolvePendingAction,
+    handleSave,
+    handleSubmit,
+    handleSettingsImport,
+    handleExport,
+  } = useImportExport({
+    token,
+    projectId,
+    view,
+    bundle,
+    dirty: view === "workspace" ? currentDocumentDirty : settingsDirty,
+    isBusy: saving || deletingDocument || creatingDocument,
+    saveCurrentDocument: (successMessage = "保存した", forceVerified = false) =>
+      saveCurrentDocumentImpl(successMessage, forceVerified),
+    saveSettings: saveSettingsImpl,
+    submitCurrentDocument: submitCurrentDocumentImpl,
+    discardCurrent: () => {
+      if (currentDocument && currentDocumentSnapshot) {
+        restoreCurrentFromSnapshot();
+        clearWorkspaceSelection();
+      }
+    },
+    discardSettings: () => {
+      if (bundle && settingsSnapshot) {
+        setBundle((current) =>
+          current
+            ? {
+                ...current,
+                project: deepClone(settingsSnapshot.project),
+                labels: deepClone(settingsSnapshot.labels),
+              }
+            : current,
+        );
+      }
+    },
+    executeAction: executePendingActionFromNavigate,
+    fetchDocumentPage,
+    showToast,
+    loadBundle,
+  });
+
   const normalizedLabelColor = normalizeHexColor(labelDraft.color);
   const labelColorValid = isHexColor(labelDraft.color);
   const labelColorPreview = labelColorValid ? normalizedLabelColor : DEFAULT_LABEL_COLOR;
 
   useBodyScrollLock();
 
-  async function loadBundle() {
-    setLoading(true);
-    const requestId = ++documentListRequestIdRef.current;
-    try {
-      const [project, { labels }, documentsResponse] = await Promise.all([
-        api.getProject(token, projectId),
-        api.listLabels(token, projectId),
-        api.listDocuments(token, projectId, {
-          offset: 0,
-          limit: DOCUMENT_PAGE_SIZE,
-          search: searchQuery,
-          sort: sortMode,
-        }),
-      ]);
-      if (requestId !== documentListRequestIdRef.current) {
-        return;
-      }
-      const firstDocId = documentsResponse.documents[0]?.id ?? null;
-      const loadedDocuments = firstDocId ? [await api.getDocument(token, projectId, firstDocId)] : [];
-      if (requestId !== documentListRequestIdRef.current) {
-        return;
-      }
-      const nextBundle = {
-        project,
-        labels,
-        documents: loadedDocuments,
-      } satisfies ProjectBundle;
-      setBundle(nextBundle);
-      setSettingsSnapshot({
-        project: deepClone(project),
-        labels: deepClone(labels),
-      });
-      setDocumentSnapshotsById(
-        Object.fromEntries(loadedDocuments.map((document) => [document.id, deepClone(document)])),
-      );
-      setHistoryState({
-        documentId: loadedDocuments[0]?.id ?? null,
-        entries: loadedDocuments[0] ? [deepClone(loadedDocuments[0])] : [],
-        index: loadedDocuments[0] ? 0 : -1,
-      });
-      setDocumentList(trimDocumentWindow(documentsResponse.documents, firstDocId));
-      setDocumentTotal(documentsResponse.total);
-      setPendingDocumentTotal(documentsResponse.pending_total);
-      setDocumentNextOffset(documentsResponse.offset + documentsResponse.documents.length);
-      initialDocumentListLoadedRef.current = true;
-      activateDocument(firstDocId);
-      setFocusedLabelId(nextBundle.labels[0]?.id ?? null);
-      setSelectedSettingsLabelId(null);
-      setLabelDraft(createEmptyLabelDraft());
-      setAccordionOpen(Object.fromEntries(nextBundle.labels.map((label) => [label.id, true])));
-    } catch (error) {
-      showToast(error instanceof Error ? error.message : "Workspace の読み込みに失敗した", "error");
-    } finally {
-      setLoading(false);
-    }
-  }
-
   useEffect(() => {
-    void loadBundle();
-  }, [projectId, token]);
-
-  useEffect(() => {
-    if (!bundle || !selectedDocId || bundle.documents.some((document) => document.id === selectedDocId)) {
+    if (!currentDocument || historyState.documentId === currentDocument.id) {
       return;
     }
-    let active = true;
-    void api
-      .getDocument(token, projectId, selectedDocId)
-      .then((document) => {
-        if (!active) {
-          return;
-        }
-        setBundle((current) =>
-          current
-            ? {
-                ...current,
-                documents: [...current.documents.filter((item) => item.id !== document.id), document],
-              }
-            : current,
-        );
-        setDocumentSnapshotsById((current) => ({
-          ...current,
-          [document.id]: deepClone(document),
-        }));
-      })
-      .catch((error) => {
-        if (active) {
-          showToast(error instanceof Error ? error.message : "Document の取得に失敗した", "error");
-        }
-      });
-    return () => {
-      active = false;
-    };
-  }, [bundle, projectId, selectedDocId, token]);
-
-  async function fetchDocumentPage(
-    reset: boolean,
-    selectedIdOverride?: string | null,
-  ): Promise<DocumentListItem[]> {
-    const requestId = ++documentListRequestIdRef.current;
-    if (!reset) {
-      setDocumentsLoadingMore(true);
-    }
-    try {
-      const response = await api.listDocuments(token, projectId, {
-        offset: reset ? 0 : documentNextOffset,
-        limit: DOCUMENT_PAGE_SIZE,
-        search: searchQuery,
-        sort: sortMode,
-      });
-      if (requestId !== documentListRequestIdRef.current) {
-        return [];
-      }
-      setDocumentTotal(response.total);
-      setPendingDocumentTotal(response.pending_total);
-      setDocumentNextOffset(response.offset + response.documents.length);
-      setDocumentList((current) =>
-        reset
-          ? trimDocumentWindow(response.documents, selectedIdOverride ?? selectedDocId)
-          : mergeDocumentWindow(current, response.documents, selectedIdOverride ?? selectedDocId),
-      );
-      return response.documents;
-    } catch (error) {
-      showToast(error instanceof Error ? error.message : "Document 一覧の取得に失敗した", "error");
-      return [];
-    } finally {
-      setDocumentsLoadingMore(false);
-    }
-  }
-
-  useEffect(() => {
-    if (!bundle || !initialDocumentListLoadedRef.current) {
-      return;
-    }
-    void fetchDocumentPage(true);
-  }, [searchQuery, sortMode]);
-
-  useEffect(() => {
-    if (!bundle) {
-      return;
-    }
-    setDocumentList((current) =>
-      current.map((item) => {
-        const loaded = bundle.documents.find((document) => document.id === item.id);
-        return loaded ? toDocumentListItem(loaded) : item;
-      }),
-    );
-  }, [bundle]);
-
-  const currentDocument = useMemo(() => {
-    if (!bundle) {
-      return null;
-    }
-    if (selectedDocId) {
-      return bundle.documents.find((document) => document.id === selectedDocId) ?? null;
-    }
-    return bundle.documents[0] ?? null;
-  }, [bundle, selectedDocId]);
-  const currentDocumentLoading = Boolean(selectedDocId && !currentDocument);
-  const currentDocumentSnapshot = currentDocument ? documentSnapshotsById[currentDocument.id] ?? null : null;
-  const workspaceBusy = saving || deletingDocument;
+    setHistoryForDocument(currentDocumentSnapshot ?? currentDocument);
+  }, [currentDocument, currentDocumentSnapshot, historyState.documentId, setHistoryForDocument]);
+  const workspaceBusy = saving || deletingDocument || creatingDocument;
 
   const focusedLabel = useMemo(
     () => bundle?.labels.find((label) => label.id === focusedLabelId) ?? bundle?.labels[0] ?? null,
@@ -342,21 +278,6 @@ export function ProjectShell({
     selectionPreview,
     showToast,
   });
-  const settingsDirty = useMemo(() => {
-    if (!bundle || !settingsSnapshot) {
-      return false;
-    }
-    return (
-      JSON.stringify(bundle.project) !== JSON.stringify(settingsSnapshot.project) ||
-      JSON.stringify(bundle.labels) !== JSON.stringify(settingsSnapshot.labels)
-    );
-  }, [bundle, settingsSnapshot]);
-  const currentDocumentDirty = useMemo(() => {
-    if (!currentDocument || !currentDocumentSnapshot) {
-      return false;
-    }
-    return JSON.stringify(currentDocument) !== JSON.stringify(currentDocumentSnapshot);
-  }, [currentDocument, currentDocumentSnapshot]);
   const dirty = view === "workspace" ? currentDocumentDirty : settingsDirty;
   const getDisplayDocumentStatus = (document: DocumentListItem) => {
     if (currentDocument?.id === document.id && currentDocumentDirty && currentDocument?.status === "verified") {
@@ -372,16 +293,6 @@ export function ProjectShell({
       currentDocument?.status === "verified" && currentDocumentDirty && !currentHiddenBySearch ? 1 : 0;
     return pendingDocumentTotal + localOffset;
   }, [currentDocument?.status, currentDocumentDirty, currentHiddenBySearch, pendingDocumentTotal]);
-  const canUndo =
-    view === "workspace" &&
-    historyState.documentId === currentDocument?.id &&
-    historyState.index > 0;
-  const canRedo =
-    view === "workspace" &&
-    historyState.documentId === currentDocument?.id &&
-    historyState.index >= 0 &&
-    historyState.index < historyState.entries.length - 1;
-
   const pinnedCurrentDocument = useMemo(() => {
     if (!currentDocument) {
       return null;
@@ -399,17 +310,6 @@ export function ProjectShell({
     () => (pinnedCurrentDocument ? [pinnedCurrentDocument, ...documentList] : documentList),
     [documentList, pinnedCurrentDocument],
   );
-
-  useEffect(() => {
-    if (!currentDocument || historyState.documentId === currentDocument.id) {
-      return;
-    }
-    setHistoryState({
-      documentId: currentDocument.id,
-      entries: [deepClone(currentDocumentSnapshot ?? currentDocument)],
-      index: 0,
-    });
-  }, [currentDocument, currentDocumentSnapshot, historyState.documentId]);
 
   function handleShortcutPanelToggle() {
     setShortcutOpen((current) => !current);
@@ -463,8 +363,8 @@ export function ProjectShell({
     onToggleShortcutPanel: handleShortcutPanelToggle,
     onSave: () => void handleSave(),
     onSubmit: () => void handleSubmit(),
-    onUndo: undoBundle,
-    onRedo: redoBundle,
+    onUndo: undo,
+    onRedo: redo,
     onMoveDocument: moveDocumentByDirection,
     onMoveLabel: moveLabelByDirection,
     onMoveRightTab: moveRightPanelTabByDirection,
@@ -493,98 +393,6 @@ export function ProjectShell({
     return () => cancelAnimationFrame(focusTimer);
   }, [deleteDialogOpen, deleteTarget]);
 
-  function mutateCurrentDocument(mutator: (draft: DocumentRecord) => void) {
-    if (!bundle || !currentDocument) {
-      return;
-    }
-    const draft = deepClone(currentDocument);
-    mutator(draft);
-    if (JSON.stringify(draft) === JSON.stringify(currentDocument)) {
-      return;
-    }
-    setBundle((current) =>
-      current
-        ? {
-            ...current,
-            documents: current.documents.map((document) => (document.id === draft.id ? draft : document)),
-          }
-        : current,
-    );
-    setHistoryState((current) => {
-      const nextEntries =
-        current.documentId === draft.id ? current.entries.slice(0, current.index + 1) : [];
-      nextEntries.push(deepClone(draft));
-      const cappedEntries = nextEntries.length > 50 ? nextEntries.slice(nextEntries.length - 50) : nextEntries;
-      return {
-        documentId: draft.id,
-        entries: cappedEntries,
-        index: cappedEntries.length - 1,
-      };
-    });
-  }
-
-  function mutateSettingsBundle(mutator: (draft: ProjectBundle) => void) {
-    if (!bundle) {
-      return;
-    }
-    const draft = deepClone(bundle);
-    mutator(draft);
-    const currentState = JSON.stringify({ project: bundle.project, labels: bundle.labels });
-    const nextState = JSON.stringify({ project: draft.project, labels: draft.labels });
-    if (currentState === nextState) {
-      return;
-    }
-    setBundle((current) =>
-      current
-        ? {
-            ...current,
-            project: draft.project,
-            labels: draft.labels,
-          }
-        : current,
-    );
-  }
-
-  function undoBundle() {
-    if (!canUndo || !currentDocument) {
-      return;
-    }
-    const nextIndex = historyState.index - 1;
-    const nextDocument = historyState.entries[nextIndex];
-    if (!nextDocument) {
-      return;
-    }
-    setBundle((current) =>
-      current
-        ? {
-            ...current,
-            documents: current.documents.map((document) => (document.id === nextDocument.id ? deepClone(nextDocument) : document)),
-          }
-        : current,
-    );
-    setHistoryState((current) => ({ ...current, index: nextIndex }));
-  }
-
-  function redoBundle() {
-    if (!canRedo || !currentDocument) {
-      return;
-    }
-    const nextIndex = historyState.index + 1;
-    const nextDocument = historyState.entries[nextIndex];
-    if (!nextDocument) {
-      return;
-    }
-    setBundle((current) =>
-      current
-        ? {
-            ...current,
-            documents: current.documents.map((document) => (document.id === nextDocument.id ? deepClone(nextDocument) : document)),
-          }
-        : current,
-    );
-    setHistoryState((current) => ({ ...current, index: nextIndex }));
-  }
-
   function buildDocumentBundlePayload(document: DocumentRecord, forceVerified: boolean) {
     return document.annotations.map((annotation) => ({
       id: isLocalId(annotation.id) ? null : annotation.id,
@@ -598,31 +406,14 @@ export function ProjectShell({
     }));
   }
 
-  async function saveCurrentDocument(successMessage: string | null = "保存した", forceVerified = false) {
+  async function saveCurrentDocumentImpl(successMessage: string | null = "保存した", forceVerified = false) {
     if (!bundle || !currentDocument) {
       return null;
     }
-    setSaving(true);
     try {
       const payload = buildDocumentBundlePayload(currentDocument, forceVerified);
       const savedDocument = await api.saveDocumentBundle(token, bundle.project.id, currentDocument.id, payload, forceVerified);
-      setBundle((current) =>
-        current
-          ? {
-              ...current,
-              documents: current.documents.map((document) => (document.id === savedDocument.id ? savedDocument : document)),
-            }
-          : current,
-      );
-      setDocumentSnapshotsById((current) => ({
-        ...current,
-        [savedDocument.id]: deepClone(savedDocument),
-      }));
-      setHistoryState({
-        documentId: savedDocument.id,
-        entries: [deepClone(savedDocument)],
-        index: 0,
-      });
+      setSavedDocument(savedDocument);
       clearWorkspaceSelection();
       if (successMessage) {
         showToast(successMessage, "success");
@@ -631,16 +422,13 @@ export function ProjectShell({
     } catch (error) {
       showToast(error instanceof Error ? error.message : "保存に失敗した", "error");
       return null;
-    } finally {
-      setSaving(false);
     }
   }
 
-  async function saveSettings(successMessage: string | null = "保存した") {
+  async function saveSettingsImpl(successMessage: string | null = "保存した") {
     if (!bundle || !settingsSnapshot) {
       return null;
     }
-    setSaving(true);
     try {
       const projectDirty = JSON.stringify(bundle.project) !== JSON.stringify(settingsSnapshot.project);
       const labelsDirty = JSON.stringify(bundle.labels) !== JSON.stringify(settingsSnapshot.labels);
@@ -712,19 +500,11 @@ export function ProjectShell({
                 }
               : {},
           );
-          setHistoryState(
-            refreshedCurrentDocument
-              ? {
-                  documentId: refreshedCurrentDocument.id,
-                  entries: [deepClone(refreshedCurrentDocument)],
-                  index: 0,
-                }
-              : {
-                  documentId: null,
-                  entries: [],
-                  index: -1,
-                },
-          );
+          if (refreshedCurrentDocument) {
+            setSavedDocument(refreshedCurrentDocument);
+          } else {
+            setHistoryForDocument(null);
+          }
           if (selectedSettingsLabel) {
             const persistedSelectedLabel = savedLabels.find((label) => label.name === selectedSettingsLabel.name) ?? null;
             setSelectedSettingsLabelId(persistedSelectedLabel?.id ?? null);
@@ -753,8 +533,6 @@ export function ProjectShell({
     } catch (error) {
       showToast(error instanceof Error ? error.message : "保存に失敗した", "error");
       return null;
-    } finally {
-      setSaving(false);
     }
   }
 
@@ -864,14 +642,14 @@ export function ProjectShell({
     clearWorkspaceSelection();
   }
 
-  async function handleSave() {
+  async function handleSaveImpl() {
     if (deletingDocument) {
       return null;
     }
     if (view === "settings") {
-      return saveSettings();
+      return saveSettingsImpl();
     }
-    const savedDocument = await saveCurrentDocument();
+    const savedDocument = await saveCurrentDocumentImpl();
     if (!savedDocument) {
       return null;
     }
@@ -879,11 +657,11 @@ export function ProjectShell({
     return savedDocument;
   }
 
-  async function handleSubmit() {
+  async function submitCurrentDocumentImpl() {
     if (!bundle || !currentDocument || view !== "workspace" || deletingDocument) {
       return;
     }
-    const savedDocument = await saveCurrentDocument(null, true);
+    const savedDocument = await saveCurrentDocumentImpl(null, true);
     if (!savedDocument) {
       return;
     }
@@ -901,7 +679,7 @@ export function ProjectShell({
     showToast("Document を submit した", "success");
   }
 
-  function executePendingAction(action: PendingAction) {
+  function executePendingActionFromNavigate(action: PendingAction) {
     if (action.type === "doc") {
       activateDocument(action.docId);
       return;
@@ -946,31 +724,8 @@ export function ProjectShell({
   }
 
   function removeDocumentFromLocalState(deletedId: string) {
-    setBundle((current) => {
-      if (!current) {
-        return current;
-      }
-      const remainingDocuments = current.documents.filter((document) => document.id !== deletedId);
-      return {
-        ...current,
-        documents: remainingDocuments,
-      };
-    });
+    removeDocumentState(deletedId);
     setDocumentList((current) => current.filter((document) => document.id !== deletedId));
-    setDocumentSnapshotsById((current) => {
-      const nextSnapshots = { ...current };
-      delete nextSnapshots[deletedId];
-      return nextSnapshots;
-    });
-    setHistoryState((current) =>
-      current.documentId === deletedId
-        ? {
-            documentId: null,
-            entries: [],
-            index: -1,
-          }
-        : current,
-    );
   }
 
   function applyDeletionResult({
@@ -996,15 +751,7 @@ export function ProjectShell({
               }
             : current,
         );
-        setDocumentSnapshotsById((current) => ({
-          ...current,
-          [nextDocument.id]: deepClone(nextDocument),
-        }));
-        setHistoryState({
-          documentId: nextDocument.id,
-          entries: [deepClone(nextDocument)],
-          index: 0,
-        });
+        setSavedDocument(nextDocument);
       }
       activateDocument(nextSelectedId);
     }
@@ -1055,59 +802,6 @@ export function ProjectShell({
     }
   }
 
-  function requestAction(action: PendingAction) {
-    if (dirty) {
-      setPendingAction(action);
-      return;
-    }
-    executePendingAction(action);
-  }
-
-  async function resolvePendingAction(mode: "save" | "discard") {
-    if (!pendingAction) {
-      return;
-    }
-    const action = pendingAction;
-    if (mode === "save") {
-      const saved = await handleSave();
-      if (!saved) {
-        return;
-      }
-      setPendingAction(null);
-      executePendingAction(action);
-      return;
-    }
-    setPendingAction(null);
-    if (view === "workspace" && currentDocument && currentDocumentSnapshot) {
-      const restoredDocument = deepClone(currentDocumentSnapshot);
-      setBundle((current) =>
-        current
-          ? {
-              ...current,
-              documents: current.documents.map((document) => (document.id === restoredDocument.id ? restoredDocument : document)),
-            }
-          : current,
-      );
-      setHistoryState({
-        documentId: restoredDocument.id,
-        entries: [deepClone(restoredDocument)],
-        index: 0,
-      });
-      clearWorkspaceSelection();
-    } else if (view === "settings" && bundle && settingsSnapshot) {
-      setBundle((current) =>
-        current
-          ? {
-              ...current,
-              project: deepClone(settingsSnapshot.project),
-              labels: deepClone(settingsSnapshot.labels),
-            }
-          : current,
-      );
-    }
-    executePendingAction(action);
-  }
-
   function handleCreateAnnotation(start: number, end: number, text: string) {
     if (!bundle || !currentDocument || !focusedLabel) {
       return;
@@ -1150,7 +844,7 @@ export function ProjectShell({
     if (!newDocName.trim() || !newDocText.trim()) {
       return;
     }
-    setSaving(true);
+    setCreatingDocument(true);
     try {
       const created = await api.createDocument(token, bundle.project.id, {
         document_name: newDocName.trim(),
@@ -1185,90 +879,7 @@ export function ProjectShell({
     } catch (error) {
       showToast(error instanceof Error ? error.message : "Document の作成に失敗した", "error");
     } finally {
-      setSaving(false);
-    }
-  }
-
-  async function handleSettingsImport() {
-    if (!settingsImportFile || !bundle || settingsImporting) {
-      return;
-    }
-    setSettingsImporting(true);
-    try {
-      const payload = await readJsonFile(settingsImportFile);
-      const basicValidation = validateImportPayload(payload);
-      if (basicValidation.issues.length > 0) {
-        const message = buildImportValidationMessage(basicValidation.issues);
-        setSettingsImportFeedback({ severity: "error", message });
-        showToast("Import 前チェックで問題を検出した", "error");
-        return;
-      }
-
-      const [{ labels: persistedLabels }, firstPageResponse] = await Promise.all([
-        api.listLabels(token, bundle.project.id),
-        api.listDocuments(token, bundle.project.id, {
-          offset: 0,
-          limit: DOCUMENT_PAGE_SIZE,
-          sort: "created",
-          search: "",
-        }),
-      ]);
-      const existingDocumentNames = await collectDocumentNames(
-        firstPageResponse.total,
-        DOCUMENT_PAGE_SIZE,
-        (offset, limit) => {
-          if (offset === 0) {
-            return Promise.resolve(firstPageResponse);
-          }
-          return api.listDocuments(token, bundle.project.id, {
-            offset,
-            limit,
-            sort: "created",
-            search: "",
-          });
-        },
-      );
-      const validation = validateImportPayload(payload, {
-        existingLabelNames: persistedLabels.map((label) => label.name),
-        existingDocumentNames,
-      });
-      if (validation.issues.length > 0) {
-        const message = buildImportValidationMessage(validation.issues);
-        setSettingsImportFeedback({ severity: "error", message });
-        showToast("Import 前チェックで問題を検出した", "error");
-        return;
-      }
-      await api.importProject(token, bundle.project.id, payload);
-      setSettingsImportFeedback({
-        severity: "success",
-        message: `Import 完了: ${describeImportSummary(
-          validation.summary ?? { labelCount: 0, documentCount: 0, annotationCount: 0 },
-        )}`,
-      });
-      showToast("現在の project に import した", "success");
-      setSettingsImportFile(null);
-      await loadBundle();
-    } catch (error) {
-      setSettingsImportFeedback({
-        severity: "error",
-        message: error instanceof Error ? error.message : "Import に失敗した",
-      });
-      showToast(error instanceof Error ? error.message : "Import に失敗した", "error");
-    } finally {
-      setSettingsImporting(false);
-    }
-  }
-
-  async function handleExport() {
-    if (!bundle) {
-      return;
-    }
-    try {
-      const payload = await api.exportProject(token, bundle.project.id, exportPending, exportVerified);
-      downloadJson(buildExportFilename(bundle.project), payload);
-      showToast("Export を開始した", "success");
-    } catch (error) {
-      showToast(error instanceof Error ? error.message : "Export に失敗した", "error");
+      setCreatingDocument(false);
     }
   }
 
@@ -1545,7 +1156,6 @@ export function ProjectShell({
             onDeleteLabel={handleDeleteLabel}
             onImportFileChange={(file) => {
               setSettingsImportFile(file);
-              setSettingsImportFeedback(null);
             }}
             onImport={() => void handleSettingsImport()}
             onExportPendingChange={setExportPending}

--- a/frontend/src/features/project-shell/useDocumentHistory.ts
+++ b/frontend/src/features/project-shell/useDocumentHistory.ts
@@ -1,0 +1,271 @@
+import { useMemo, useState } from "react";
+import type { ProjectBundle, DocumentRecord } from "../../types";
+import { deepClone } from "../../utils";
+
+export type HistoryState = {
+  documentId: string | null;
+  entries: DocumentRecord[];
+  index: number;
+};
+
+type SetBundle = React.Dispatch<React.SetStateAction<ProjectBundle | null>>;
+
+export type UseDocumentHistoryResult = {
+  documentSnapshotsById: Record<string, DocumentRecord>;
+  setDocumentSnapshotsById: React.Dispatch<React.SetStateAction<Record<string, DocumentRecord>>>;
+  historyState: HistoryState;
+  setHistoryState: React.Dispatch<React.SetStateAction<HistoryState>>;
+  currentDocumentSnapshot: DocumentRecord | null;
+  currentDocumentDirty: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
+  setHistoryForDocument: (document: DocumentRecord | null) => void;
+  setSavedDocument: (document: DocumentRecord) => void;
+  removeDocumentState: (documentId: string) => void;
+  mutateCurrentDocument: (mutator: (draft: DocumentRecord) => void) => void;
+  mutateSettingsBundle: (mutator: (draft: ProjectBundle) => void) => void;
+  undo: () => void;
+  redo: () => void;
+  restoreCurrentFromSnapshot: () => void;
+};
+
+export function useDocumentHistory({
+  bundle,
+  currentDocument,
+  setBundle,
+}: {
+  bundle: ProjectBundle | null;
+  currentDocument: DocumentRecord | null;
+  setBundle: SetBundle;
+}): UseDocumentHistoryResult {
+  const [documentSnapshotsById, setDocumentSnapshotsById] = useState<Record<string, DocumentRecord>>({});
+  const [historyState, setHistoryState] = useState<HistoryState>({
+    documentId: null,
+    entries: [],
+    index: -1,
+  });
+
+  const currentDocumentSnapshot = currentDocument ? documentSnapshotsById[currentDocument.id] ?? null : null;
+  const currentDocumentDirty = useMemo(() => {
+    if (!currentDocument || !currentDocumentSnapshot) {
+      return false;
+    }
+    return JSON.stringify(currentDocument) !== JSON.stringify(currentDocumentSnapshot);
+  }, [currentDocument, currentDocumentSnapshot]);
+
+  const canUndo =
+    currentDocument !== null &&
+    historyState.documentId === currentDocument.id &&
+    historyState.index > 0;
+
+  const canRedo =
+    currentDocument !== null &&
+    historyState.documentId === currentDocument.id &&
+    historyState.index >= 0 &&
+    historyState.index < historyState.entries.length - 1;
+
+  function setHistoryForDocument(document: DocumentRecord | null) {
+    if (document === null) {
+      setDocumentSnapshotsById((current) => {
+        if (Object.keys(current).length === 0) {
+          return current;
+        }
+        return {};
+      });
+      setHistoryState({
+        documentId: null,
+        entries: [],
+        index: -1,
+      });
+      return;
+    }
+    const snapshot = deepClone(document);
+    setDocumentSnapshotsById((current) => ({
+      ...current,
+      [document.id]: snapshot,
+    }));
+    setHistoryState({
+      documentId: document.id,
+      entries: [snapshot],
+      index: 0,
+    });
+  }
+
+  function setSavedDocument(document: DocumentRecord) {
+    const saved = deepClone(document);
+    setBundle((current) =>
+      current
+        ? {
+            ...current,
+            documents: current.documents.map((item) => (item.id === saved.id ? saved : item)),
+          }
+        : current,
+    );
+    setDocumentSnapshotsById((current) => ({
+      ...current,
+      [saved.id]: deepClone(saved),
+    }));
+    setHistoryState({
+      documentId: saved.id,
+      entries: [deepClone(saved)],
+      index: 0,
+    });
+  }
+
+  function removeDocumentState(documentId: string) {
+    setBundle((current) =>
+      current
+        ? {
+            ...current,
+            documents: current.documents.filter((item) => item.id !== documentId),
+          }
+        : current,
+    );
+    setDocumentSnapshotsById((current) => {
+      const nextSnapshots = { ...current };
+      delete nextSnapshots[documentId];
+      return nextSnapshots;
+    });
+    setHistoryState((current) =>
+      current.documentId === documentId
+        ? {
+            documentId: null,
+            entries: [],
+            index: -1,
+          }
+        : current,
+    );
+  }
+
+  function mutateCurrentDocument(mutator: (draft: DocumentRecord) => void) {
+    if (!bundle || !currentDocument) {
+      return;
+    }
+    const draft = deepClone(currentDocument);
+    mutator(draft);
+    if (JSON.stringify(draft) === JSON.stringify(currentDocument)) {
+      return;
+    }
+    setBundle((current) =>
+      current
+        ? {
+            ...current,
+            documents: current.documents.map((document) => (document.id === draft.id ? draft : document)),
+          }
+        : current,
+    );
+    setHistoryState((current) => {
+      const nextEntries = current.documentId === draft.id ? current.entries.slice(0, current.index + 1) : [];
+      nextEntries.push(deepClone(draft));
+      const cappedEntries = nextEntries.length > 50 ? nextEntries.slice(nextEntries.length - 50) : nextEntries;
+      return {
+        documentId: draft.id,
+        entries: cappedEntries,
+        index: cappedEntries.length - 1,
+      };
+    });
+  }
+
+  function mutateSettingsBundle(mutator: (draft: ProjectBundle) => void) {
+    if (!bundle) {
+      return;
+    }
+    const draft = deepClone(bundle);
+    mutator(draft);
+    const currentState = JSON.stringify({ project: bundle.project, labels: bundle.labels });
+    const nextState = JSON.stringify({ project: draft.project, labels: draft.labels });
+    if (currentState === nextState) {
+      return;
+    }
+    setBundle((current) =>
+      current
+        ? {
+            ...current,
+            project: draft.project,
+            labels: draft.labels,
+          }
+        : current,
+    );
+  }
+
+  function undo() {
+    if (!canUndo || !currentDocument) {
+      return;
+    }
+    const nextIndex = historyState.index - 1;
+    const nextDocument = historyState.entries[nextIndex];
+    if (!nextDocument) {
+      return;
+    }
+    const restored = deepClone(nextDocument);
+    setBundle((current) =>
+      current
+        ? {
+            ...current,
+            documents: current.documents.map((document) => (document.id === restored.id ? restored : document)),
+          }
+        : current,
+    );
+    setHistoryState((current) => ({ ...current, index: nextIndex }));
+  }
+
+  function redo() {
+    if (!canRedo || !currentDocument) {
+      return;
+    }
+    const nextIndex = historyState.index + 1;
+    const nextDocument = historyState.entries[nextIndex];
+    if (!nextDocument) {
+      return;
+    }
+    const restored = deepClone(nextDocument);
+    setBundle((current) =>
+      current
+        ? {
+            ...current,
+            documents: current.documents.map((document) => (document.id === restored.id ? restored : document)),
+          }
+        : current,
+    );
+    setHistoryState((current) => ({ ...current, index: nextIndex }));
+  }
+
+  function restoreCurrentFromSnapshot() {
+    if (!currentDocument || !currentDocumentSnapshot) {
+      return;
+    }
+    const restored = deepClone(currentDocumentSnapshot);
+    setBundle((current) =>
+      current
+        ? {
+            ...current,
+            documents: current.documents.map((document) => (document.id === restored.id ? restored : document)),
+          }
+        : current,
+    );
+    setHistoryState({
+      documentId: restored.id,
+      entries: [deepClone(restored)],
+      index: 0,
+    });
+  }
+
+  return {
+    documentSnapshotsById,
+    setDocumentSnapshotsById,
+    historyState,
+    setHistoryState,
+    currentDocumentSnapshot,
+    currentDocumentDirty,
+    canUndo,
+    canRedo,
+    setHistoryForDocument,
+    setSavedDocument,
+    removeDocumentState,
+    mutateCurrentDocument,
+    mutateSettingsBundle,
+    undo,
+    redo,
+    restoreCurrentFromSnapshot,
+  };
+}

--- a/frontend/src/features/project-shell/useImportExport.ts
+++ b/frontend/src/features/project-shell/useImportExport.ts
@@ -1,0 +1,269 @@
+import { useState } from "react";
+import { api } from "../../api";
+import { buildExportFilename, downloadJson, readJsonFile } from "../../utils";
+import { buildImportValidationMessage, describeImportSummary, validateImportPayload } from "../../importValidation";
+import { collectDocumentNames } from "./projectShellUtils";
+import { DOCUMENT_PAGE_SIZE } from "./projectShellConstants";
+import type { DocumentListItem, DocumentRecord, LabelRecord, ProjectBundle, ProjectRecord } from "../../types";
+import type { PendingAction } from "./projectShellTypes";
+
+type ToastHandler = (message: string, severity?: "success" | "info" | "warning" | "error") => void;
+
+export type ImportExportSaveResult =
+  | { kind: "document"; document: DocumentRecord }
+  | { kind: "settings"; project: ProjectRecord; labels: LabelRecord[] }
+  | { kind: "none" };
+
+export type UseImportExportResult = {
+  saving: boolean;
+  pendingAction: PendingAction | null;
+  setPendingAction: React.Dispatch<React.SetStateAction<PendingAction | null>>;
+  settingsImportFile: File | null;
+  setSettingsImportFile: React.Dispatch<React.SetStateAction<File | null>>;
+  settingsImportFeedback: {
+    severity: "success" | "info" | "warning" | "error";
+    message: string;
+  } | null;
+  settingsImporting: boolean;
+  exportPending: boolean;
+  setExportPending: React.Dispatch<React.SetStateAction<boolean>>;
+  exportVerified: boolean;
+  setExportVerified: React.Dispatch<React.SetStateAction<boolean>>;
+  requestAction: (action: PendingAction) => void;
+  resolvePendingAction: (mode: "save" | "discard") => Promise<void>;
+  handleSave: () => Promise<ImportExportSaveResult | null>;
+  handleSubmit: () => Promise<void>;
+  handleSettingsImport: () => Promise<void>;
+  handleExport: () => Promise<void>;
+};
+
+type SaveCurrentDocument = (successMessage?: string | null, forceVerified?: boolean) => Promise<DocumentRecord | null> | null;
+type SaveSettings = (
+  successMessage?: string | null,
+) => Promise<{ project: ProjectRecord; labels: LabelRecord[] } | null> | null;
+type SubmitCurrentDocument = () => Promise<unknown> | void;
+
+export function useImportExport({
+  token,
+  projectId,
+  view,
+  bundle,
+  dirty,
+  isBusy,
+  saveCurrentDocument,
+  saveSettings,
+  submitCurrentDocument,
+  discardCurrent,
+  discardSettings,
+  executeAction,
+  fetchDocumentPage,
+  showToast,
+  loadBundle,
+}: {
+  token: string;
+  projectId: string;
+  view: "workspace" | "settings";
+  bundle: ProjectBundle | null;
+  dirty: boolean;
+  isBusy: boolean;
+  saveCurrentDocument: SaveCurrentDocument;
+  saveSettings: SaveSettings;
+  submitCurrentDocument: SubmitCurrentDocument;
+  discardCurrent: () => void;
+  discardSettings: () => void;
+  executeAction: (action: PendingAction) => void;
+  fetchDocumentPage: (reset: boolean, selectedIdOverride?: string | null) => Promise<DocumentListItem[]>;
+  showToast: ToastHandler;
+  loadBundle: () => Promise<void>;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  const [settingsImportFile, setSettingsImportFile] = useState<File | null>(null);
+  const [settingsImportFeedback, setSettingsImportFeedback] = useState<{
+    severity: "success" | "info" | "warning" | "error";
+    message: string;
+  } | null>(null);
+  const [settingsImporting, setSettingsImporting] = useState(false);
+  const [exportPending, setExportPending] = useState(true);
+  const [exportVerified, setExportVerified] = useState(true);
+
+  function requestAction(action: PendingAction) {
+    if (dirty) {
+      setPendingAction(action);
+      return;
+    }
+    executeAction(action);
+  }
+
+  async function handleSave(): Promise<ImportExportSaveResult | null> {
+    if (isBusy) {
+      return null;
+    }
+
+    setSaving(true);
+    try {
+      if (view === "settings") {
+        const savedSettings = await saveSettings();
+        if (!savedSettings) {
+          return null;
+        }
+        return { kind: "settings", ...savedSettings };
+      }
+
+      const savedDocument = await saveCurrentDocument();
+      if (!savedDocument) {
+        return null;
+      }
+      await fetchDocumentPage(true, savedDocument.id);
+      return { kind: "document", document: savedDocument };
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "保存に失敗した", "error");
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleSubmit() {
+    if (view !== "workspace" || isBusy) {
+      return;
+    }
+    setSaving(true);
+    try {
+      await submitCurrentDocument();
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "submit に失敗した", "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function resolvePendingAction(mode: "save" | "discard") {
+    if (!pendingAction) {
+      return;
+    }
+    const action = pendingAction;
+    if (mode === "save") {
+      const saved = await handleSave();
+      if (!saved) {
+        return;
+      }
+      setPendingAction(null);
+      executeAction(action);
+      return;
+    }
+
+    if (view === "workspace") {
+      discardCurrent();
+    } else {
+      discardSettings();
+    }
+    setPendingAction(null);
+    executeAction(action);
+  }
+
+  async function handleSettingsImport() {
+    if (!settingsImportFile || !bundle || settingsImporting) {
+      return;
+    }
+
+    setSettingsImporting(true);
+    setSettingsImportFeedback(null);
+    try {
+      const payload = await readJsonFile(settingsImportFile);
+      const basicValidation = validateImportPayload(payload);
+      if (basicValidation.issues.length > 0) {
+        const message = buildImportValidationMessage(basicValidation.issues);
+        setSettingsImportFeedback({ severity: "error", message });
+        showToast("Import 前チェックで問題を検出した", "error");
+        return;
+      }
+
+      const [{ labels: persistedLabels }, firstPageResponse] = await Promise.all([
+        api.listLabels(token, bundle.project.id),
+        api.listDocuments(token, bundle.project.id, {
+          offset: 0,
+          limit: DOCUMENT_PAGE_SIZE,
+          sort: "created",
+          search: "",
+        }),
+      ]);
+      const existingDocumentNames = await collectDocumentNames(
+        firstPageResponse.total,
+        DOCUMENT_PAGE_SIZE,
+        (offset, limit) => {
+          if (offset === 0) {
+            return Promise.resolve(firstPageResponse);
+          }
+          return api.listDocuments(token, bundle.project.id, {
+            offset,
+            limit,
+            sort: "created",
+            search: "",
+          });
+        },
+      );
+      const validation = validateImportPayload(payload, {
+        existingLabelNames: persistedLabels.map((label) => label.name),
+        existingDocumentNames,
+      });
+      if (validation.issues.length > 0) {
+        const message = buildImportValidationMessage(validation.issues);
+        setSettingsImportFeedback({ severity: "error", message });
+        showToast("Import 前チェックで問題を検出した", "error");
+        return;
+      }
+      await api.importProject(token, bundle.project.id, payload);
+      setSettingsImportFeedback({
+        severity: "success",
+        message: `Import 完了: ${describeImportSummary(
+          validation.summary ?? { labelCount: 0, documentCount: 0, annotationCount: 0 },
+        )}`,
+      });
+      showToast("現在の project に import した", "success");
+      setSettingsImportFile(null);
+      await loadBundle();
+    } catch (error) {
+      setSettingsImportFeedback({
+        severity: "error",
+        message: error instanceof Error ? error.message : "Import に失敗した",
+      });
+      showToast(error instanceof Error ? error.message : "Import に失敗した", "error");
+    } finally {
+      setSettingsImporting(false);
+    }
+  }
+
+  async function handleExport() {
+    if (!bundle) {
+      return;
+    }
+    try {
+      const payload = await api.exportProject(token, bundle.project.id, exportPending, exportVerified);
+      downloadJson(buildExportFilename(bundle.project), payload);
+      showToast("Export を開始した", "success");
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "Export に失敗した", "error");
+    }
+  }
+
+  return {
+    saving,
+    pendingAction,
+    setPendingAction,
+    settingsImportFile,
+    setSettingsImportFile,
+    settingsImportFeedback,
+    settingsImporting,
+    exportPending,
+    setExportPending,
+    exportVerified,
+    setExportVerified,
+    requestAction,
+    resolvePendingAction,
+    handleSave,
+    handleSubmit,
+    handleSettingsImport,
+    handleExport,
+  };
+}

--- a/frontend/src/features/project-shell/useProjectBundle.ts
+++ b/frontend/src/features/project-shell/useProjectBundle.ts
@@ -1,0 +1,246 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api } from "../../api";
+import type { DocumentRecord, DocumentListItem, ProjectBundle } from "../../types";
+import { deepClone } from "../../utils";
+import { DOCUMENT_PAGE_SIZE } from "./projectShellConstants";
+import { mergeDocumentWindow, toDocumentListItem, trimDocumentWindow } from "./projectShellUtils";
+
+type ToastSeverity = "success" | "info" | "warning" | "error";
+type ToastHandler = (message: string, severity?: ToastSeverity) => void;
+
+export type UseProjectBundleResult = {
+  loading: boolean;
+  bundle: ProjectBundle | null;
+  setBundle: React.Dispatch<React.SetStateAction<ProjectBundle | null>>;
+  settingsSnapshot: Pick<ProjectBundle, "project" | "labels"> | null;
+  setSettingsSnapshot: React.Dispatch<React.SetStateAction<Pick<ProjectBundle, "project" | "labels"> | null>>;
+  selectedDocId: string | null;
+  setSelectedDocId: React.Dispatch<React.SetStateAction<string | null>>;
+  focusedLabelId: string | null;
+  setFocusedLabelId: React.Dispatch<React.SetStateAction<string | null>>;
+  searchQuery: string;
+  setSearchQuery: React.Dispatch<React.SetStateAction<string>>;
+  sortMode: string;
+  setSortMode: React.Dispatch<React.SetStateAction<string>>;
+  documentList: DocumentListItem[];
+  setDocumentList: React.Dispatch<React.SetStateAction<DocumentListItem[]>>;
+  documentTotal: number;
+  setDocumentTotal: React.Dispatch<React.SetStateAction<number>>;
+  pendingDocumentTotal: number;
+  setPendingDocumentTotal: React.Dispatch<React.SetStateAction<number>>;
+  documentNextOffset: number;
+  setDocumentNextOffset: React.Dispatch<React.SetStateAction<number>>;
+  documentsLoadingMore: boolean;
+  setDocumentsLoadingMore: React.Dispatch<React.SetStateAction<boolean>>;
+  currentDocument: DocumentRecord | null;
+  currentDocumentLoading: boolean;
+  loadBundle: () => Promise<void>;
+  fetchDocumentPage: (reset: boolean, selectedIdOverride?: string | null) => Promise<DocumentListItem[]>;
+};
+
+export function useProjectBundle({
+  token,
+  projectId,
+  showToast,
+  onBundleLoaded = () => {},
+}: {
+  token: string;
+  projectId: string;
+  showToast: ToastHandler;
+  onBundleLoaded?: (payload: {
+    bundle: ProjectBundle;
+    firstDocument: DocumentRecord | null;
+    firstDocId: string | null;
+  }) => void;
+}): UseProjectBundleResult {
+  const [loading, setLoading] = useState(true);
+  const [bundle, setBundle] = useState<ProjectBundle | null>(null);
+  const [settingsSnapshot, setSettingsSnapshot] = useState<Pick<ProjectBundle, "project" | "labels"> | null>(null);
+  const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
+  const [focusedLabelId, setFocusedLabelId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortMode, setSortMode] = useState("created");
+  const [documentList, setDocumentList] = useState<DocumentListItem[]>([]);
+  const [documentTotal, setDocumentTotal] = useState(0);
+  const [pendingDocumentTotal, setPendingDocumentTotal] = useState(0);
+  const [documentNextOffset, setDocumentNextOffset] = useState(0);
+  const [documentsLoadingMore, setDocumentsLoadingMore] = useState(false);
+  const documentListRequestIdRef = useRef(0);
+  const initialDocumentListLoadedRef = useRef(false);
+
+  const activateDocument = useCallback((documentId: string | null) => {
+    setSelectedDocId(documentId);
+  }, []);
+
+  const loadBundle = useCallback(async () => {
+    setLoading(true);
+    const requestId = ++documentListRequestIdRef.current;
+    try {
+      const [project, { labels }, documentsResponse] = await Promise.all([
+        api.getProject(token, projectId),
+        api.listLabels(token, projectId),
+        api.listDocuments(token, projectId, {
+          offset: 0,
+          limit: DOCUMENT_PAGE_SIZE,
+          search: searchQuery,
+          sort: sortMode,
+        }),
+      ]);
+      if (requestId !== documentListRequestIdRef.current) {
+        return;
+      }
+      const firstDocId = documentsResponse.documents[0]?.id ?? null;
+      const loadedDocuments = firstDocId ? [await api.getDocument(token, projectId, firstDocId)] : [];
+      if (requestId !== documentListRequestIdRef.current) {
+        return;
+      }
+      const nextBundle = {
+        project,
+        labels,
+        documents: loadedDocuments,
+      } satisfies ProjectBundle;
+      setBundle(nextBundle);
+      setSettingsSnapshot({
+        project: deepClone(project),
+        labels: deepClone(labels),
+      });
+      setDocumentList(trimDocumentWindow(documentsResponse.documents, firstDocId));
+      setDocumentTotal(documentsResponse.total);
+      setPendingDocumentTotal(documentsResponse.pending_total);
+      setDocumentNextOffset(documentsResponse.offset + documentsResponse.documents.length);
+      initialDocumentListLoadedRef.current = true;
+      activateDocument(firstDocId);
+      onBundleLoaded({
+        bundle: nextBundle,
+        firstDocument: loadedDocuments[0] ?? null,
+        firstDocId,
+      });
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "Workspace の読み込みに失敗した", "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [token, projectId, searchQuery, sortMode, onBundleLoaded, showToast, activateDocument]);
+
+  const fetchDocumentPage = useCallback(
+    async (reset: boolean, selectedIdOverride?: string | null): Promise<DocumentListItem[]> => {
+      const requestId = ++documentListRequestIdRef.current;
+      if (!reset) {
+        setDocumentsLoadingMore(true);
+      }
+      try {
+        const response = await api.listDocuments(token, projectId, {
+          offset: reset ? 0 : documentNextOffset,
+          limit: DOCUMENT_PAGE_SIZE,
+          search: searchQuery,
+          sort: sortMode,
+        });
+        if (requestId !== documentListRequestIdRef.current) {
+          return [];
+        }
+        setDocumentTotal(response.total);
+        setPendingDocumentTotal(response.pending_total);
+        setDocumentNextOffset(response.offset + response.documents.length);
+        setDocumentList((current) =>
+          reset
+            ? trimDocumentWindow(response.documents, selectedIdOverride ?? selectedDocId)
+            : mergeDocumentWindow(current, response.documents, selectedIdOverride ?? selectedDocId),
+        );
+        return response.documents;
+      } catch (error) {
+        showToast(error instanceof Error ? error.message : "Document 一覧の取得に失敗した", "error");
+        return [];
+      } finally {
+        setDocumentsLoadingMore(false);
+      }
+    },
+    [token, projectId, documentNextOffset, searchQuery, sortMode, selectedDocId, showToast],
+  );
+
+  useEffect(() => {
+    void loadBundle();
+  }, [projectId, token, loadBundle]);
+
+  useEffect(() => {
+    if (!bundle || !selectedDocId || bundle.documents.some((document) => document.id === selectedDocId)) {
+      return;
+    }
+    let active = true;
+    void api
+      .getDocument(token, projectId, selectedDocId)
+      .then((document) => {
+        if (!active) {
+          return;
+        }
+        setBundle((current) =>
+          current
+            ? {
+                ...current,
+                documents: [...current.documents.filter((item) => item.id !== document.id), document],
+              }
+            : current,
+        );
+      })
+      .catch((error) => {
+        if (active) {
+          showToast(error instanceof Error ? error.message : "Document の取得に失敗した", "error");
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [bundle, projectId, selectedDocId, token, showToast]);
+
+  useEffect(() => {
+    if (!bundle || !initialDocumentListLoadedRef.current) {
+      return;
+    }
+    void fetchDocumentPage(true);
+  }, [searchQuery, sortMode]);
+
+  useEffect(() => {
+    if (!bundle) {
+      return;
+    }
+    setDocumentList((current) =>
+      current.map((item) => {
+        const loaded = bundle.documents.find((document) => document.id === item.id);
+        return loaded ? toDocumentListItem(loaded) : item;
+      }),
+    );
+  }, [bundle]);
+
+  const currentDocument =
+    !bundle ? null : selectedDocId ? bundle.documents.find((document) => document.id === selectedDocId) ?? null : bundle.documents[0] ?? null;
+  const currentDocumentLoading = Boolean(selectedDocId && !currentDocument);
+
+  return {
+    loading,
+    bundle,
+    setBundle,
+    settingsSnapshot,
+    setSettingsSnapshot,
+    selectedDocId,
+    setSelectedDocId,
+    focusedLabelId,
+    setFocusedLabelId,
+    searchQuery,
+    setSearchQuery,
+    sortMode,
+    setSortMode,
+    documentList,
+    setDocumentList,
+    documentTotal,
+    setDocumentTotal,
+    pendingDocumentTotal,
+    setPendingDocumentTotal,
+    documentNextOffset,
+    setDocumentNextOffset,
+    documentsLoadingMore,
+    setDocumentsLoadingMore,
+    currentDocument,
+    currentDocumentLoading,
+    loadBundle,
+    fetchDocumentPage,
+  };
+}

--- a/frontend/src/test/useDocumentHistory.test.tsx
+++ b/frontend/src/test/useDocumentHistory.test.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import { act, render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useDocumentHistory } from "../features/project-shell/useDocumentHistory";
+import type { DocumentRecord } from "../types";
+
+type UseDocumentHistoryResult = ReturnType<typeof useDocumentHistory>;
+
+function createDocument(id: string): DocumentRecord {
+  return {
+    id,
+    project_id: "project-1",
+    project_name: "Medical NER",
+    document_name: `Doc ${id}`,
+    text: "text",
+    status: "pending",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    annotations: [],
+    meta: {},
+  };
+}
+
+function renderHistoryHook() {
+  const stateRef: { current: UseDocumentHistoryResult | null } = { current: null };
+  const bundleRef: { current: { documents: Array<{ document_name: string }> } | null } = { current: null };
+  const document = createDocument("doc-1");
+
+  function HistoryHarness() {
+    const [bundle, setBundle] = useState({
+      project: {
+        id: "project-1",
+        name: "Medical NER",
+        description: null,
+        meta: {},
+      },
+      labels: [],
+      documents: [document],
+    });
+    bundleRef.current = bundle;
+
+    stateRef.current = useDocumentHistory({
+      bundle,
+      currentDocument: bundle.documents[0],
+      setBundle,
+    });
+
+    return null;
+  }
+
+  render(<HistoryHarness />);
+
+  return { stateRef, bundleRef };
+}
+
+describe("useDocumentHistory", () => {
+  it("tracks dirty and supports undo/redo on current document", async () => {
+    const { stateRef, bundleRef } = renderHistoryHook();
+
+    await waitFor(() => {
+      expect(stateRef.current).not.toBeNull();
+    });
+
+    act(() => {
+      stateRef.current?.setHistoryForDocument(createDocument("doc-1"));
+    });
+    expect(stateRef.current?.currentDocumentDirty).toBe(false);
+
+    act(() => {
+      stateRef.current?.mutateCurrentDocument((draft) => {
+        draft.document_name = "Updated";
+      });
+    });
+    expect(stateRef.current?.currentDocumentDirty).toBe(true);
+    expect(stateRef.current?.canUndo).toBe(true);
+
+    act(() => {
+      stateRef.current?.undo();
+    });
+    expect(bundleRef.current?.documents[0]?.document_name).toBe("Doc doc-1");
+    expect(stateRef.current?.currentDocumentDirty).toBe(false);
+
+    act(() => {
+      stateRef.current?.redo();
+    });
+    expect(bundleRef.current?.documents[0]?.document_name).toBe("Updated");
+    expect(stateRef.current?.currentDocumentDirty).toBe(true);
+  });
+
+  it("removes snapshots and history when document is removed", async () => {
+    const { stateRef } = renderHistoryHook();
+
+    await waitFor(() => {
+      expect(stateRef.current).not.toBeNull();
+    });
+
+    act(() => {
+      stateRef.current?.setHistoryForDocument(createDocument("doc-1"));
+      stateRef.current?.setSavedDocument(createDocument("doc-1"));
+    });
+    act(() => {
+      stateRef.current?.removeDocumentState("doc-1");
+    });
+
+    expect(stateRef.current?.documentSnapshotsById["doc-1"]).toBeUndefined();
+    expect(stateRef.current?.historyState.documentId).toBeNull();
+  });
+});

--- a/frontend/src/test/useImportExport.test.tsx
+++ b/frontend/src/test/useImportExport.test.tsx
@@ -1,0 +1,255 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useImportExport } from "../features/project-shell/useImportExport";
+import { api } from "../api";
+import * as utils from "../utils";
+import type { DocumentListItem, DocumentRecord, ProjectBundle, LabelRecord, ProjectRecord } from "../types";
+
+type UseImportExportResult = ReturnType<typeof useImportExport>;
+
+function createProject(): ProjectRecord {
+  return {
+    id: "project-1",
+    name: "Medical NER",
+    description: "",
+    meta: {},
+  };
+}
+
+function createBundle(project = createProject()): ProjectBundle {
+  return {
+    project,
+    labels: [
+      {
+        id: "label-1",
+        project_id: "project-1",
+        project_name: project.name,
+        name: "主訴",
+        color: "#ff0000",
+        description: "",
+        shortcut: null,
+        meta: {},
+      },
+    ],
+    documents: [],
+  };
+}
+
+function createDocumentRecord(): DocumentRecord {
+  return {
+    id: "doc-1",
+    project_id: "project-1",
+    project_name: "Medical NER",
+    document_name: "Doc 1",
+    text: "text",
+    status: "pending",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    annotations: [],
+    meta: {},
+  };
+}
+
+function createImportPayload() {
+  return {
+    project: { name: "Imported Project" },
+    labels: [{ name: "Imported", color: "#00aa00", description: "imported", shortcut: null, meta: {} }],
+    documents: [
+      {
+        document_name: "Imported Doc",
+        text: "text",
+        status: "pending",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        annotations: [],
+      },
+    ],
+  } as const;
+}
+
+function renderImportExportHook({
+  view = "workspace",
+  dirty = false,
+  isBusy = false,
+  saveCurrentDocument = vi.fn().mockResolvedValue(createDocumentRecord()),
+  saveSettings = vi.fn().mockResolvedValue({ project: createProject(), labels: [] as LabelRecord[] }),
+  submitCurrentDocument = vi.fn(),
+  fetchDocumentPage = vi.fn().mockResolvedValue([] as DocumentListItem[]),
+  bundle = createBundle(),
+  discardCurrent = vi.fn(),
+  discardSettings = vi.fn(),
+  executeAction = vi.fn(),
+  loadBundle = vi.fn().mockResolvedValue(undefined),
+  showToast = vi.fn(),
+}: {
+  view?: "workspace" | "settings";
+  dirty?: boolean;
+  isBusy?: boolean;
+  saveCurrentDocument?: () => Promise<DocumentRecord | null> | null;
+  saveSettings?: () => Promise<{ project: ProjectRecord; labels: LabelRecord[] } | null> | null;
+  submitCurrentDocument?: () => Promise<unknown> | void;
+  fetchDocumentPage?: (reset: boolean, selectedIdOverride?: string | null) => Promise<DocumentListItem[]>;
+  bundle?: ProjectBundle;
+  discardCurrent?: () => void;
+  discardSettings?: () => void;
+  executeAction?: (action: { type: "doc"; docId: string } | { type: "settings" } | { type: "workspace" } | { type: "projects" }) => void;
+  loadBundle?: () => Promise<void>;
+  showToast?: (message: string, severity?: "success" | "info" | "warning" | "error") => void;
+}) {
+  const stateRef: { current: UseImportExportResult | null } = { current: null };
+
+  function Harness() {
+    const state = useImportExport({
+      token: "token",
+      projectId: "project-1",
+      view,
+      bundle,
+      dirty,
+      isBusy,
+      saveCurrentDocument,
+      saveSettings,
+      submitCurrentDocument,
+      discardCurrent,
+      discardSettings,
+      executeAction,
+      fetchDocumentPage,
+      showToast,
+      loadBundle,
+    });
+    stateRef.current = state;
+    return null;
+  }
+
+  render(<Harness />);
+
+  return { stateRef, executeAction, discardCurrent, discardSettings, saveCurrentDocument, fetchDocumentPage, loadBundle };
+}
+
+describe("useImportExport", () => {
+  it("executes action immediately when not dirty", async () => {
+    const executeAction = vi.fn();
+    const { stateRef } = renderImportExportHook({ dirty: false, executeAction });
+
+    await waitFor(() => expect(stateRef.current).not.toBeNull());
+    act(() => {
+      stateRef.current?.requestAction({ type: "doc", docId: "doc-2" });
+    });
+
+    expect(executeAction).toHaveBeenCalledWith({ type: "doc", docId: "doc-2" });
+    expect(stateRef.current?.pendingAction).toBeNull();
+  });
+
+  it("stores pending action while dirty and resolves via discard", async () => {
+    const executeAction = vi.fn();
+    const discardCurrent = vi.fn();
+    const { stateRef } = renderImportExportHook({ dirty: true, executeAction, discardCurrent });
+
+    await waitFor(() => expect(stateRef.current).not.toBeNull());
+    act(() => {
+      stateRef.current?.requestAction({ type: "doc", docId: "doc-2" });
+    });
+
+    expect(stateRef.current?.pendingAction).toEqual({ type: "doc", docId: "doc-2" });
+
+    act(() => {
+      stateRef.current?.resolvePendingAction("discard");
+    });
+
+    expect(discardCurrent).toHaveBeenCalledTimes(1);
+    expect(executeAction).toHaveBeenCalledWith({ type: "doc", docId: "doc-2" });
+    expect(stateRef.current?.pendingAction).toBeNull();
+  });
+
+  it("stores pending action while dirty and resolves via save", async () => {
+    const executeAction = vi.fn();
+    const fetchDocumentPage = vi.fn().mockResolvedValue([]);
+    const saveCurrentDocument = vi.fn().mockResolvedValue(createDocumentRecord());
+    const { stateRef } = renderImportExportHook({
+      dirty: true,
+      executeAction,
+      saveCurrentDocument,
+      fetchDocumentPage,
+    });
+
+    await waitFor(() => expect(stateRef.current).not.toBeNull());
+    act(() => {
+      stateRef.current?.requestAction({ type: "doc", docId: "doc-1" });
+    });
+    await act(async () => {
+      await stateRef.current?.resolvePendingAction("save");
+    });
+
+    expect(saveCurrentDocument).toHaveBeenCalledTimes(1);
+    expect(fetchDocumentPage).toHaveBeenCalledWith(true, "doc-1");
+    expect(executeAction).toHaveBeenCalledWith({ type: "doc", docId: "doc-1" });
+  });
+
+  it("imports valid settings payload and updates feedback", async () => {
+    vi.spyOn(api, "listLabels").mockResolvedValue({ labels: [] });
+    vi.spyOn(api, "listDocuments").mockResolvedValue({
+      documents: [],
+      total: 0,
+      pending_total: 0,
+      offset: 0,
+      limit: 40,
+      search: "",
+      sort: "created",
+    });
+    const importProject = vi
+      .spyOn(api, "importProject")
+      .mockResolvedValue({ imported: { labels: 1, documents: 1, annotations: 0 }, errors: [] });
+    const loadBundle = vi.fn().mockResolvedValue(undefined);
+
+    const { stateRef } = renderImportExportHook({ view: "settings", loadBundle });
+    const file = new File([JSON.stringify(createImportPayload())], "import.json", { type: "application/json" });
+
+    await waitFor(() => expect(stateRef.current).not.toBeNull());
+    act(() => {
+      stateRef.current?.setSettingsImportFile(file);
+    });
+
+    await act(async () => {
+      await stateRef.current?.handleSettingsImport();
+    });
+
+    expect(importProject).toHaveBeenCalledTimes(1);
+    expect(loadBundle).toHaveBeenCalledTimes(1);
+    expect(stateRef.current?.settingsImportFeedback?.severity).toBe("success");
+  });
+
+  it("blocks import on validation failure", async () => {
+    const importProject = vi.spyOn(api, "importProject");
+    const { stateRef } = renderImportExportHook({ view: "settings" });
+    const file = new File([JSON.stringify({})], "invalid.json", { type: "application/json" });
+
+    await waitFor(() => expect(stateRef.current).not.toBeNull());
+    act(() => {
+      stateRef.current?.setSettingsImportFile(file);
+    });
+    await act(async () => {
+      await stateRef.current?.handleSettingsImport();
+    });
+
+    expect(importProject).not.toHaveBeenCalled();
+    expect(stateRef.current?.settingsImportFeedback?.severity).toBe("error");
+  });
+
+  it("exports bundle with current options", async () => {
+    vi.spyOn(api, "exportProject").mockResolvedValue({
+      project: createProject(),
+      labels: [],
+      documents: [],
+      meta: {},
+    });
+    const downloadSpy = vi.spyOn(utils, "downloadJson").mockImplementation(() => {});
+    const { stateRef } = renderImportExportHook({});
+
+    await waitFor(() => expect(stateRef.current).not.toBeNull());
+    await act(async () => {
+      await stateRef.current?.handleExport();
+    });
+
+    expect(api.exportProject).toHaveBeenCalledWith("token", "project-1", true, true);
+    expect(downloadSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/test/useProjectBundle.test.tsx
+++ b/frontend/src/test/useProjectBundle.test.tsx
@@ -1,0 +1,166 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DOCUMENT_PAGE_SIZE } from "../features/project-shell/projectShellConstants";
+import { useProjectBundle } from "../features/project-shell/useProjectBundle";
+import { api } from "../api";
+import type { DocumentListItem, DocumentRecord, LabelRecord, ProjectRecord } from "../types";
+
+type UseProjectBundleResult = ReturnType<typeof useProjectBundle>;
+
+function createProject(): ProjectRecord {
+  return {
+    id: "project-1",
+    name: "Medical NER",
+    description: "desc",
+    meta: {},
+  };
+}
+
+function createLabel(id: string, name: string): LabelRecord {
+  return {
+    id,
+    project_id: "project-1",
+    project_name: "Medical NER",
+    name,
+    color: "#ff0000",
+    description: "",
+    shortcut: null,
+    meta: {},
+  };
+}
+
+function createDocumentRecord(id: string, status: "pending" | "verified"): DocumentRecord {
+  return {
+    id,
+    project_id: "project-1",
+    project_name: "Medical NER",
+    document_name: `Doc ${id}`,
+    text: "text",
+    status,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    annotations: [],
+    meta: {},
+  };
+}
+
+function createDocumentListItem(document: DocumentRecord): DocumentListItem {
+  return {
+    id: document.id,
+    project_id: document.project_id,
+    project_name: document.project_name ?? "",
+    document_name: document.document_name,
+    text: document.text,
+    status: document.status,
+    created_at: document.created_at,
+    updated_at: document.updated_at,
+    meta: document.meta,
+  };
+}
+
+function renderBundleHook() {
+  const resultRef: { current: UseProjectBundleResult | null } = { current: null };
+
+  function BundleHarness() {
+    const result = useProjectBundle({
+      token: "token",
+      projectId: "project-1",
+      showToast: vi.fn(),
+      onBundleLoaded: vi.fn(),
+    });
+    resultRef.current = result;
+    return null;
+  }
+
+  render(<BundleHarness />);
+  return resultRef;
+}
+
+describe("useProjectBundle", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loads bundle data and selected document on mount", async () => {
+    const project = createProject();
+    const labels = [createLabel("label-1", "主訴")];
+    const loadedDocument = createDocumentRecord("doc-1", "pending");
+    const documents = [createDocumentListItem(loadedDocument)];
+
+    vi.spyOn(api, "getProject").mockResolvedValue(project);
+    vi.spyOn(api, "listLabels").mockResolvedValue({ labels });
+    vi.spyOn(api, "listDocuments").mockResolvedValue({
+      documents,
+      total: 1,
+      pending_total: 1,
+      offset: 0,
+      limit: DOCUMENT_PAGE_SIZE,
+      search: "",
+      sort: "created",
+    });
+    vi.spyOn(api, "getDocument").mockResolvedValue(loadedDocument);
+
+    const result = renderBundleHook();
+
+    await waitFor(() => expect(result.current?.loading).toBe(false));
+    expect(result.current?.bundle?.project).toEqual(project);
+    expect(result.current?.bundle?.labels).toEqual(labels);
+    expect(result.current?.bundle?.documents.length).toBe(1);
+    expect(result.current?.currentDocument).toMatchObject({ id: "doc-1" });
+    expect(result.current?.selectedDocId).toBe("doc-1");
+  });
+
+  it("reloads document list when search query changes", async () => {
+    const project = createProject();
+    const labels = [createLabel("label-1", "主訴")];
+    const loadedDocument = createDocumentRecord("doc-1", "pending");
+    const secondDocument = createDocumentRecord("doc-2", "pending");
+    const documents = [createDocumentListItem(loadedDocument)];
+    const searchResult = [createDocumentListItem(secondDocument)];
+    const listDocumentsMock = vi
+      .spyOn(api, "listDocuments")
+      .mockResolvedValueOnce({
+        documents,
+        total: 1,
+        pending_total: 1,
+        offset: 0,
+        limit: DOCUMENT_PAGE_SIZE,
+        search: "",
+        sort: "created",
+      })
+      .mockResolvedValueOnce({
+        documents: searchResult,
+        total: 1,
+        pending_total: 0,
+        offset: 0,
+        limit: DOCUMENT_PAGE_SIZE,
+        search: "query",
+        sort: "created",
+      });
+    vi.spyOn(api, "getProject").mockResolvedValue(project);
+    vi.spyOn(api, "listLabels").mockResolvedValue({ labels });
+    vi.spyOn(api, "getDocument").mockResolvedValue(loadedDocument);
+
+    const result = renderBundleHook();
+    await waitFor(() => expect(result.current?.loading).toBe(false));
+
+    act(() => {
+      result.current?.setSearchQuery("query");
+    });
+
+    await waitFor(() => {
+      expect(listDocumentsMock).toHaveBeenCalledTimes(2);
+    });
+    expect(listDocumentsMock).toHaveBeenLastCalledWith("token", "project-1", {
+      offset: 0,
+      limit: DOCUMENT_PAGE_SIZE,
+      search: "query",
+      sort: "created",
+    });
+    expect(result.current?.documentList).toEqual(searchResult);
+  });
+});


### PR DESCRIPTION
## Summary
- App.tsx を機能責務ごとに分離し、プロジェクトバンドル読込、履歴管理、保存/Import/Export/遷移ガードを各 hooks に委譲。
- 追加した hooks: useProjectBundle / useDocumentHistory / useImportExport。
- 回帰防止用の hook 単体テストを追加。

## Notes
- 実装は既存のUI/APIフローを維持し、挙動を変えないことを前提に整理。
- テスト実行は未実施（必要なら PR で CI 結果を確認）。