### PR TITLE
Document PATCH endpoint を削除し、Document を作成後不変に整理

### DIFF
--- a/backend/src/layered_span_studio_backend/api/documents.py
+++ b/backend/src/layered_span_studio_backend/api/documents.py
@@ -11,7 +11,6 @@ from layered_span_studio_backend.models.documents import (
     DocumentListSort,
     DocumentNavigationResponse,
     DocumentOut,
-    DocumentUpdate,
 )
 from layered_span_studio_backend.services import documents_service
 
@@ -129,25 +128,6 @@ def save_document_bundle(
         if "not found" in message.lower():
             status_code = status.HTTP_404_NOT_FOUND
         raise HTTPException(status_code=status_code, detail=message)
-
-
-@router.patch("/{document_id}", response_model=DocumentOut)
-def update_document(
-    project_id: str, document_id: str, payload: DocumentUpdate, settings=Depends(get_settings)
-):
-    try:
-        document = documents_service.update_document(
-            settings, project_id, document_id, payload.document_name, payload.meta
-        )
-    except ValueError as exc:
-        message = str(exc)
-        status_code = status.HTTP_400_BAD_REQUEST
-        if "Project not found" in message:
-            status_code = status.HTTP_404_NOT_FOUND
-        raise HTTPException(status_code=status_code, detail=message)
-    if not document:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found")
-    return document
 
 
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/layered_span_studio_backend/models/documents.py
+++ b/backend/src/layered_span_studio_backend/models/documents.py
@@ -23,11 +23,6 @@ class DocumentCreate(APIModel):
     meta: Meta = None
 
 
-class DocumentUpdate(APIModel):
-    document_name: Optional[str] = None
-    meta: Meta = None
-
-
 class DocumentBundleAnnotationIn(APIModel):
     id: Optional[str] = None
     label_id: str

--- a/backend/src/layered_span_studio_backend/repositories/documents.py
+++ b/backend/src/layered_span_studio_backend/repositories/documents.py
@@ -334,43 +334,6 @@ def create_document(
     )
 
 
-def update_document(
-    settings: Settings,
-    project_id: str,
-    document_id: str,
-    document_name: Optional[str],
-    meta: Optional[Dict[str, Any]],
-) -> Optional[Dict[str, Any]]:
-    document = get_document(settings, project_id, document_id)
-    if not document:
-        return None
-    new_name = document_name if document_name is not None else document["document_name"]
-    new_meta = _sanitize_document_meta(meta) if meta is not None else document.get("meta") or {}
-    new_updated_at = _utc_now_iso()
-
-    db_path = project_db_path(settings, project_id)
-    engine = get_project_engine(str(db_path))
-    with engine.begin() as conn:
-        conn.execute(
-            documents_table.update().where(documents_table.c.id == document_id).values(
-                document_name=new_name,
-                updated_at=new_updated_at,
-                meta=encode_meta(new_meta),
-            )
-        )
-    return {
-        "id": document_id,
-        "project_id": project_id,
-        "project_name": document["project_name"],
-        "document_name": new_name,
-        "text": document["text"],
-        "status": document["status"],
-        "created_at": document["created_at"],
-        "updated_at": new_updated_at,
-        "meta": new_meta,
-    }
-
-
 def set_document_system_fields(
     settings: Settings,
     project_id: str,

--- a/backend/src/layered_span_studio_backend/services/documents_service.py
+++ b/backend/src/layered_span_studio_backend/services/documents_service.py
@@ -104,22 +104,6 @@ def _validate_document_bundle(
         label_spans.append((start, end))
 
 
-def update_document(
-    settings: Settings,
-    project_id: str,
-    document_id: str,
-    document_name: Optional[str],
-    meta: Optional[Dict[str, Any]],
-) -> Optional[Dict[str, Any]]:
-    _ensure_project(settings, project_id)
-    if document_name is not None:
-        if documents_repo.document_name_exists(
-            settings, project_id, document_name, exclude_document_id=document_id
-        ):
-            raise ValueError("Document name already exists in this project")
-    return documents_repo.update_document(settings, project_id, document_id, document_name, meta)
-
-
 def delete_document(settings: Settings, project_id: str, document_id: str) -> bool:
     _ensure_project(settings, project_id)
     return documents_repo.delete_document(settings, project_id, document_id)

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -64,18 +64,11 @@ def test_document_crud(client: TestClient, auth_headers: dict[str, str]) -> None
     assert response.status_code == 200
     assert response.json()["annotations"] == []
 
-    response = client.patch(
-        f"/projects/{project_id}/documents/{document_id}",
-        json={"document_name": "Doc1Updated"},
-        headers=auth_headers,
-    )
-    assert response.status_code == 200
-
     response = client.delete(f"/projects/{project_id}/documents/{document_id}", headers=auth_headers)
     assert response.status_code == 204
 
 
-def test_document_text_update_forbidden(client: TestClient, auth_headers: dict[str, str]) -> None:
+def test_document_patch_is_not_supported(client: TestClient, auth_headers: dict[str, str]) -> None:
     project_id = _create_project(client, auth_headers)
     response = client.post(
         f"/projects/{project_id}/documents",
@@ -86,10 +79,10 @@ def test_document_text_update_forbidden(client: TestClient, auth_headers: dict[s
 
     response = client.patch(
         f"/projects/{project_id}/documents/{document_id}",
-        json={"text": "New text"},
+        json={"document_name": "Doc1Updated", "meta": {"reviewed": True}},
         headers=auth_headers,
     )
-    assert response.status_code == 422
+    assert response.status_code == 405
 
 
 def test_document_list_supports_search_sort_and_pending_total(
@@ -406,9 +399,7 @@ def test_document_navigation_returns_404_when_document_does_not_exist(
     assert response.json()["detail"] == "Document not found"
 
 
-def test_document_create_and_update_reject_duplicate_name(
-    client: TestClient, auth_headers: dict[str, str]
-) -> None:
+def test_document_create_rejects_duplicate_name(client: TestClient, auth_headers: dict[str, str]) -> None:
     project_id = _create_project(client, auth_headers)
     first = client.post(
         f"/projects/{project_id}/documents",
@@ -423,21 +414,6 @@ def test_document_create_and_update_reject_duplicate_name(
         headers=auth_headers,
     )
     assert duplicate_create.status_code == 400
-
-    second = client.post(
-        f"/projects/{project_id}/documents",
-        json={"document_name": "Doc2", "text": "Second body"},
-        headers=auth_headers,
-    )
-    assert second.status_code == 201
-
-    duplicate_update = client.patch(
-        f"/projects/{project_id}/documents/{second.json()['id']}",
-        json={"document_name": "Doc1"},
-        headers=auth_headers,
-    )
-    assert duplicate_update.status_code == 400
-
 
 def test_document_create_sets_server_managed_fields(client: TestClient, auth_headers: dict[str, str]) -> None:
     project_id = _create_project(client, auth_headers)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -396,7 +396,6 @@ PUT    /projects/{project_id}/labels                             # ラベル一�
 GET    /projects/{project_id}/documents                          # ドキュメント一覧
 POST   /projects/{project_id}/documents                          # ドキュメント作成
 GET    /projects/{project_id}/documents/{document_id}            # ドキュメント取得
-PATCH  /projects/{project_id}/documents/{document_id}            # ドキュメント部分更新
 DELETE /projects/{project_id}/documents/{document_id}            # ドキュメント削除
 
 GET    /projects/{project_id}/annotations/search                 # アノテーション横断検索

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -55,7 +55,6 @@
 - `GET /projects/{project_id}/documents/{document_id}/navigation` - 現在 document 基準の `prev/next/next_pending` を取得
 - `GET /projects/{project_id}/documents/{document_id}` - ドキュメント詳細を取得（`annotations` 全件含む）
 - `PUT /projects/{project_id}/documents/{document_id}/bundle` - 現在 document の annotation 一覧を一括保存
-- `PATCH /projects/{project_id}/documents/{document_id}` - ドキュメントの `document_name` / `meta` を更新（`text` は更新不可）
 - `DELETE /projects/{project_id}/documents/{document_id}` - ドキュメントを削除（関連アノテも連動削除）
 
 ### Annotations
@@ -972,52 +971,6 @@ Authorization: Bearer <token>
 
 ---
 
-### PATCH /projects/{project_id}/documents/{document_id}
-
-ドキュメントのメタデータを更新する。
-
-**Headers:**
-```
-Authorization: Bearer <token>
-```
-
-**Request:**
-```json
-{
-  "document_name": "患者記録_001_revised",
-  "meta": {
-    "source": "hospital_records",
-    "date": "2024-01-15",
-    "reviewed": true
-  }
-}
-```
-
-**Response (200 OK):**
-```json
-{
-  "id": "uuid",
-  "project_id": "uuid",
-  "project_name": "医療文書NER",
-  "document_name": "患者記録_001_revised",
-  "text": "患者は頭痛を訴え、アスピリンを処方された。既往歴に糖尿病あり。",
-  "status": "pending",
-  "created_at": "2026-03-11T01:23:45Z",
-  "updated_at": "2026-03-12T02:00:00Z",
-  "meta": {
-    "source": "hospital_records",
-    "date": "2024-01-15",
-    "reviewed": true
-  }
-}
-```
-
-**注記:**
-- `text` フィールドは更新不可（既存のアノテーションが壊れるため）
-- `document_name` と `meta` のみ更新可能
-
----
-
 ### PUT /projects/{project_id}/documents/{document_id}/bundle
 
 現在の document に対する annotation 一覧を一括保存する。request の `annotations` はその document の最終状態全件を表す。通常の Save では現在状態をそのまま送り、Submit では frontend が `pending` を `verified` に変換したうえで同じ endpoint に送る。
@@ -1062,6 +1015,7 @@ Authorization: Bearer <token>
 - `GET /projects/{project_id}/documents/{document_id}` と同じ full document を返す
 
 **注記:**
+- `document_name` / `text` / `meta` はこの endpoint では更新しない
 - request に含まれない既存 annotation は削除される
 - `id: null` は新規 annotation として作成される
 - 既存 annotation の `label_id/start/end/span_text` は変更不可

--- a/docs/backend/json-schema.md
+++ b/docs/backend/json-schema.md
@@ -418,6 +418,8 @@ response 例:
 
 - request の `annotations` は対象 document の最終状態全件を表す
 - `submit` は optional。未指定時は `false`
+- `document_name` と `text` は document 作成後に固定であり、更新 API は持たない
+- `meta` は Document の属性として保持するが、現時点では更新 API を持たない
 - `id: null` は新規 annotation
 - request に含まれない既存 annotation は削除される
 - response は full `Document` を返す


### PR DESCRIPTION
## 概要
- `PATCH /projects/{project_id}/documents/{document_id}` を削除
- Document は作成後に `document_name` / `text` を変更しない前提へ整理
- backend テストと関連 docs を現行 API 契約に合わせて更新

## 変更内容
- backend の documents API / service / repository / model から Document PATCH 用実装を削除
- `backend/tests/test_documents.py` を更新し、PATCH 非対応 (`405`) を確認する回帰テストへ置換
- `docs/backend/api.md`, `docs/backend/json-schema.md`, `docs/architecture.md` を更新
  - Documents API 一覧から PATCH を削除
  - `bundle` は `annotations` / `submit` のみを扱うことを明記
  - `document_name` / `text` は作成後固定、`meta` は保持するが更新 API は未提供であることを明記

## 確認
- `cd backend && uv run pytest tests/test_documents.py tests/test_annotations.py tests/test_import_export.py tests/test_projects.py`
- `cd frontend && npm run build`

## Codex Review
- `codex review --commit HEAD` を 3 回実行
- 3 回とも新たな指摘なしを確認
