### PR TITLE
fix: ProjectShell header の横伸びと account 表示を調整

### DIFF
--- a/docs/frontend/workspace-spec.md
+++ b/docs/frontend/workspace-spec.md
@@ -168,6 +168,7 @@
 
 ## 6.3 Project Settings 画面
 
+- Project scope 共通 header では、左側に project 名と説明文、中央に `Workspace / Project Settings` 切り替え、右側に現在の username と logout 導線をまとめて表示する。
 - Project 名と説明文を編集可能にする。
 - Label定義管理を行う（追加 / 編集 / 削除）。
 - Label削除時は対応するAnnotationも同時に除去する。

--- a/frontend/src/features/project-shell/ProjectShellHeader.tsx
+++ b/frontend/src/features/project-shell/ProjectShellHeader.tsx
@@ -1,4 +1,4 @@
-import { AppBar, Box, Button, IconButton, Stack, Tab, Tabs, Toolbar, Tooltip, Typography } from "@mui/material";
+import { AppBar, Button, IconButton, Stack, Tab, Tabs, Toolbar, Tooltip, Typography } from "@mui/material";
 import ArrowBackRoundedIcon from "@mui/icons-material/ArrowBackRounded";
 import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
 import LogoutRoundedIcon from "@mui/icons-material/LogoutRounded";
@@ -31,17 +31,18 @@ export function ProjectShellHeader({
         <Button color="inherit" startIcon={<ArrowBackRoundedIcon />} onClick={onBackToProjects} sx={{ flexShrink: 0 }}>
           Projects
         </Button>
-        <Stack sx={{ minWidth: 0, flexGrow: 1, flexShrink: 1, flexBasis: 0, overflow: "hidden" }}>
+        <Stack sx={{ minWidth: 0, width: 0, maxWidth: "100%", flexGrow: 1, flexShrink: 1, flexBasis: 0, overflow: "hidden" }}>
           <Typography variant="h6" noWrap sx={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
             {bundle.project.name}
           </Typography>
           <Typography
             variant="body2"
+            component="div"
             color="text.secondary"
             noWrap
-            sx={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+            sx={{ minWidth: 0, display: "block", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
           >
-            {bundle.project.description || "説明なし"} / {user.username}
+            {bundle.project.description || "説明なし"}
           </Typography>
         </Stack>
         <Tabs value={view} onChange={(_event, nextView) => onChangeView(nextView)} sx={{ minHeight: 0, flexShrink: 0 }}>
@@ -53,9 +54,31 @@ export function ProjectShellHeader({
             <HelpOutlineRoundedIcon />
           </IconButton>
         </Tooltip>
-        <Button onClick={onLogout} color="inherit" startIcon={<LogoutRoundedIcon />} sx={{ flexShrink: 0 }}>
-          Logout
-        </Button>
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          sx={{
+            flexShrink: 0,
+            px: 1.25,
+            py: 0.5,
+            borderRadius: 999,
+            border: "1px solid #d7e2f0",
+            bgcolor: "rgba(22, 50, 79, 0.04)",
+          }}
+        >
+          <Typography variant="caption" color="text.secondary" noWrap sx={{ maxWidth: 160, fontWeight: 700, lineHeight: 1 }}>
+            {user.username}
+          </Typography>
+          <Button
+            onClick={onLogout}
+            color="inherit"
+            startIcon={<LogoutRoundedIcon />}
+            sx={{ flexShrink: 0, minWidth: "auto", px: 1, py: 0.5, borderRadius: 999, lineHeight: 1 }}
+          >
+            Logout
+          </Button>
+        </Stack>
       </Toolbar>
     </AppBar>
   );

--- a/frontend/src/test/projectShellHeader.test.tsx
+++ b/frontend/src/test/projectShellHeader.test.tsx
@@ -44,7 +44,7 @@ describe("ProjectShellHeader", () => {
     const projectsButton = screen.getByRole("button", { name: "Projects" });
     const toolbar = projectsButton.parentElement;
     const title = screen.getByText(longProjectName);
-    const description = screen.getByText(`${longProjectDescription} / ${user.username}`);
+    const description = screen.getByText(longProjectDescription);
     const metadataStack = title.parentElement;
 
     if (!(toolbar instanceof HTMLElement)) {
@@ -57,6 +57,8 @@ describe("ProjectShellHeader", () => {
     expect(toolbar).toHaveStyle({ minWidth: "0px", overflow: "hidden" });
     expect(metadataStack).toHaveStyle({
       minWidth: "0px",
+      width: "0px",
+      maxWidth: "100%",
       overflow: "hidden",
       flexGrow: "1",
       flexShrink: "1",
@@ -70,10 +72,13 @@ describe("ProjectShellHeader", () => {
     });
     expect(description).toHaveStyle({
       minWidth: "0px",
+      display: "block",
       overflow: "hidden",
       textOverflow: "ellipsis",
       whiteSpace: "nowrap",
     });
+    expect(screen.queryByText(`${longProjectDescription} / ${user.username}`)).not.toBeInTheDocument();
+    expect(screen.getByText(user.username)).toBeVisible();
     expect(screen.getByRole("tab", { name: "Workspace" })).toBeVisible();
     expect(screen.getByRole("tab", { name: "Project Settings" })).toBeVisible();
     expect(screen.getByRole("button", { name: "ショートカット一覧" })).toBeVisible();


### PR DESCRIPTION
## 概要
- 長い project description で ProjectShell header が横方向に崩れる問題を修正
- description 行から username を外し、右端に username + Logout の account 領域を追加
- header 表示仕様を docs に追記し、関連テストを更新

## 変更内容
- metadata コンテナの幅制御を強化し、長文でも header 全体が押し広がらないよう修正
- 右上に username と Logout を一体化した UI を追加
- header テストで shrink 条件と username 表示位置を検証
- workspace spec に Project scope 共通 header の仕様を追記

## テスト
- npm test -- --run src/test/projectShellHeader.test.tsx src/test/workspaceView.test.tsx
- npm test
- npm run build

## 補足
- gpt-5.3-codex-spark によるレビューを 2 回実施し、最終結果は no findings