### PR TITLE
Project importの永続化を一括化する

### DIFF
--- a/backend/src/layered_span_studio_backend/repositories/bulk_import.py
+++ b/backend/src/layered_span_studio_backend/repositories/bulk_import.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List
+
+from layered_span_studio_backend.core.config import Settings
+from layered_span_studio_backend.repositories.projects import project_db_path
+from layered_span_studio_backend.storage.project_db import (
+    annotations_table,
+    documents_table,
+    get_project_engine,
+    labels_table,
+)
+from layered_span_studio_backend.utils.json_utils import encode_meta
+
+DOCUMENT_SYSTEM_FIELD_KEYS = {"status", "created_at", "updated_at"}
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _sanitize_document_meta(meta: Dict[str, Any] | None) -> Dict[str, Any]:
+    return {
+        key: value
+        for key, value in (meta or {}).items()
+        if key not in DOCUMENT_SYSTEM_FIELD_KEYS
+    }
+
+
+def import_entities(
+    settings: Settings,
+    project_id: str,
+    existing_label_by_name: Dict[str, Dict[str, Any]],
+    incoming_labels: List[Dict[str, Any]],
+    incoming_documents: List[Dict[str, Any]],
+) -> None:
+    db_path = project_db_path(settings, project_id)
+    engine = get_project_engine(str(db_path))
+
+    label_id_by_name = {
+        name: label["id"] for name, label in existing_label_by_name.items()
+    }
+    label_rows = []
+    for label in incoming_labels:
+        label_id = _new_id()
+        label_id_by_name[label["name"]] = label_id
+        label_rows.append(
+            {
+                "id": label_id,
+                "project_id": project_id,
+                "name": label["name"],
+                "color": label["color"],
+                "description": label["description"],
+                "shortcut": label.get("shortcut"),
+                "meta": encode_meta(label.get("meta")),
+            }
+        )
+
+    document_rows = []
+    annotation_rows = []
+    for doc in incoming_documents:
+        document_id = _new_id()
+        document_rows.append(
+            {
+                "id": document_id,
+                "project_id": project_id,
+                "document_name": doc["document_name"],
+                "text": doc["text"],
+                "status": doc["status"],
+                "created_at": doc["created_at"],
+                "updated_at": doc["updated_at"],
+                "meta": encode_meta(_sanitize_document_meta(doc.get("meta"))),
+            }
+        )
+        for ann in doc.get("annotations", []):
+            annotation_rows.append(
+                {
+                    "id": _new_id(),
+                    "document_id": document_id,
+                    "label_id": label_id_by_name[ann["label_name"]],
+                    "start": ann["start"],
+                    "end": ann["end"],
+                    "span_text": ann["span_text"],
+                    "comment": ann.get("comment", ""),
+                    "status": ann["status"],
+                    "meta": encode_meta(ann.get("meta")),
+                }
+            )
+
+    with engine.begin() as conn:
+        if label_rows:
+            conn.execute(labels_table.insert(), label_rows)
+        if document_rows:
+            conn.execute(documents_table.insert(), document_rows)
+        if annotation_rows:
+            conn.execute(annotations_table.insert(), annotation_rows)

--- a/backend/src/layered_span_studio_backend/services/import_export_service.py
+++ b/backend/src/layered_span_studio_backend/services/import_export_service.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 from layered_span_studio_backend.core.config import Settings
-from layered_span_studio_backend.repositories import annotations as annotations_repo
+from layered_span_studio_backend.repositories import bulk_import as bulk_import_repo
 from layered_span_studio_backend.repositories import documents as documents_repo
 from layered_span_studio_backend.repositories import labels as labels_repo
 from layered_span_studio_backend.repositories import projects as projects_repo
@@ -273,54 +273,13 @@ def _import_entities(
     incoming_labels: List[Dict[str, Any]],
     incoming_documents: List[Dict[str, Any]],
 ) -> Dict[str, int]:
-    label_id_by_name: Dict[str, str] = {
-        name: label["id"] for name, label in existing_label_by_name.items()
-    }
-    for label in incoming_labels:
-        created = labels_repo.create_label(
-            settings,
-            project_id,
-            label["name"],
-            label["color"],
-            label["description"],
-            label.get("shortcut"),
-            label.get("meta"),
-        )
-        label_id_by_name[created["name"]] = created["id"]
-
-    for doc in incoming_documents:
-        created_doc = documents_repo.create_document_with_system_fields(
-            settings,
-            project_id,
-            doc["document_name"],
-            doc["text"],
-            doc.get("meta"),
-            status=doc["status"],
-            created_at=doc["created_at"],
-            updated_at=doc["updated_at"],
-        )
-        for ann in doc.get("annotations", []):
-            annotations_repo.create_annotation(
-                settings,
-                project_id,
-                created_doc["id"],
-                label_id_by_name[ann["label_name"]],
-                ann["start"],
-                ann["end"],
-                ann["span_text"],
-                ann.get("comment", ""),
-                ann["status"],
-                ann.get("meta"),
-            )
-        documents_repo.set_document_system_fields(
-            settings,
-            project_id,
-            created_doc["id"],
-            status=doc["status"],
-            created_at=doc["created_at"],
-            updated_at=doc["updated_at"],
-        )
-
+    bulk_import_repo.import_entities(
+        settings,
+        project_id,
+        existing_label_by_name,
+        incoming_labels,
+        incoming_documents,
+    )
     return _build_import_counts(incoming_labels, incoming_documents)
 
 

--- a/backend/tests/test_import_export.py
+++ b/backend/tests/test_import_export.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from conftest import create_label_via_sync
+from layered_span_studio_backend.repositories import bulk_import as bulk_import_repo
 
 JSONDict = dict[str, Any]
 
@@ -209,6 +210,75 @@ def test_existing_import_appends_without_updating_project_metadata(
     assert target_detail.json()["name"] == "Project C"
     assert target_detail.json()["description"] == "target desc"
     assert target_detail.json()["meta"] == {"keep": "yes"}
+
+
+def test_existing_import_rolls_back_bulk_persistence_failure(
+    client: TestClient, auth_headers: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target_project = client.post(
+        "/projects",
+        json={"name": "Project Import Rollback", "description": "desc"},
+        headers=auth_headers,
+    ).json()
+    payload = {
+        "project": {"name": "Project Import Rollback", "description": "desc", "meta": {}},
+        "labels": [
+            {
+                "name": "LabelRollback",
+                "color": "#AA1122",
+                "description": "desc",
+                "shortcut": None,
+                "meta": {},
+            }
+        ],
+        "documents": [
+            _import_document_payload(
+                "DocRollback",
+                "Hello world",
+                [
+                    {
+                        "label_name": "LabelRollback",
+                        "start": 0,
+                        "end": 5,
+                        "span_text": "Hello",
+                        "comment": "",
+                        "status": "verified",
+                        "meta": {},
+                    },
+                    {
+                        "label_name": "LabelRollback",
+                        "start": 6,
+                        "end": 11,
+                        "span_text": "world",
+                        "comment": "",
+                        "status": "verified",
+                        "meta": {},
+                    }
+                ],
+                status="verified",
+            )
+        ],
+        "meta": {"format": "layered-span-studio/export", "version": "1.0"},
+    }
+    ids = iter(["label-id", "document-id", "annotation-id", "annotation-id"])
+    monkeypatch.setattr(bulk_import_repo, "_new_id", lambda: next(ids))
+
+    with TestClient(client.app, raise_server_exceptions=False) as unsafe_client:
+        response = unsafe_client.post(
+            f"/projects/{target_project['id']}/import", json=payload, headers=auth_headers
+        )
+
+    assert response.status_code >= 400
+    labels_response = client.get(
+        f"/projects/{target_project['id']}/labels", headers=auth_headers
+    )
+    documents_response = client.get(
+        f"/projects/{target_project['id']}/documents", headers=auth_headers
+    )
+    assert labels_response.status_code == 200
+    assert documents_response.status_code == 200
+    assert labels_response.json()["labels"] == []
+    assert documents_response.json()["documents"] == []
 
 
 def test_export_filters_by_status(client: TestClient, auth_headers: dict[str, str]) -> None:


### PR DESCRIPTION
## Summary
- Project import 専用の bulk persistence path を追加し、label / document / annotation を単一 transaction で保存するように変更
- import 経路では annotation ごとの再取得や document updated_at touch を避け、payload の document system fields を最終状態として保存
- 既存 project への append import で永続化途中に失敗しても部分反映が残らないことをテストで確認

## Test plan
- `cd backend && uv run pytest tests/test_import_export.py`
- `cd backend && uv run pytest`

Closes #39