### PR TITLE
DocumentCanvasのspan描画を高速化

### DIFF
--- a/frontend/src/components/DocumentCanvas.tsx
+++ b/frontend/src/components/DocumentCanvas.tsx
@@ -1,8 +1,21 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Box, Button, Paper, Typography, alpha } from "@mui/material";
-import type { AnnotationRecord, DocumentRecord, LabelRecord } from "../api-contract";
+import type { DocumentRecord, LabelRecord } from "../api-contract";
 import { useI18n } from "../i18n/useI18n";
 import { isShortcutBlockedTarget } from "../utils";
+import {
+  UNDERLINE_HIT_HEIGHT,
+  UNDERLINE_LANE_BASE,
+  UNDERLINE_LANE_PITCH,
+  buildAnnotationById,
+  buildRectsByAnnotationId,
+  buildSegments,
+  buildUnderlineLaneByAnnotation,
+  isBoxInViewport,
+  mergeInlineRects,
+  mixColorWithBlack,
+  getSelectionOffset,
+} from "./documentCanvasLayout";
 
 type SelectionDraft = {
   start: number;
@@ -12,141 +25,19 @@ type SelectionDraft = {
   left: number;
 };
 
-const UNDERLINE_LANE_BASE = 5.0;
-const UNDERLINE_LANE_PITCH = 4.4;
-const UNDERLINE_PADDING_TAIL = 5;
-const UNDERLINE_HIT_HEIGHT = 5;
+type MarkerBox = { annotationId: string; left: number; top: number; width: number; height: number; color: string };
+type OverlayLine = { annotationId: string; left: number; top: number; width: number; color: string };
+type SelectionBox = { left: number; top: number; width: number; height: number; color: string };
 
-function getSelectionOffset(container: HTMLElement, node: Node, offset: number) {
-  let total = 0;
-  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
-  while (walker.nextNode()) {
-    const currentNode = walker.currentNode;
-    const length = currentNode.textContent?.length ?? 0;
-    if (currentNode === node) {
-      return total + offset;
-    }
-    total += length;
+function areOverlayItemsEqual<T extends object>(left: T[], right: T[]) {
+  if (left.length !== right.length) {
+    return false;
   }
-  return total;
-}
-
-function mixColorWithBlack(hexColor: string, ratio = 0.5) {
-  const normalized = hexColor.replace("#", "");
-  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) {
-    return "#1d1d1d";
-  }
-  const channels = [0, 2, 4].map((offset) => Number.parseInt(normalized.slice(offset, offset + 2), 16));
-  const mixed = channels.map((channel) => Math.round(channel * (1 - ratio)));
-  return `rgb(${mixed[0]}, ${mixed[1]}, ${mixed[2]})`;
-}
-
-function buildSegments(
-  text: string,
-  annotations: AnnotationRecord[],
-  focusedLabelId: string | null,
-  selectedAnnotationId: string | null,
-) {
-  const boundaries = new Set<number>([0, text.length]);
-  annotations.forEach((annotation) => {
-    boundaries.add(annotation.start);
-    boundaries.add(annotation.end);
+  return left.every((leftItem, index) => {
+    const rightItem = right[index];
+    const keys = Object.keys(leftItem) as Array<keyof T>;
+    return keys.every((key) => leftItem[key] === rightItem[key]);
   });
-  const sorted = [...boundaries].sort((a, b) => a - b);
-  const segments: Array<{
-    id: string;
-    text: string;
-    covers: AnnotationRecord[];
-    focused: AnnotationRecord[];
-    selected: boolean;
-  }> = [];
-
-  for (let index = 0; index < sorted.length - 1; index += 1) {
-    const start = sorted[index];
-    const end = sorted[index + 1];
-    if (start === end) {
-      continue;
-    }
-    const cover = annotations.filter((annotation) => annotation.start < end && annotation.end > start);
-    segments.push({
-      id: `${start}-${end}`,
-      text: text.slice(start, end),
-      covers: cover,
-      focused: cover.filter((annotation) => annotation.label_id === focusedLabelId),
-      selected: cover.some((annotation) => annotation.id === selectedAnnotationId),
-    });
-  }
-
-  return segments;
-}
-
-function buildUnderlineLaneByAnnotation(
-  annotations: AnnotationRecord[],
-  labels: LabelRecord[],
-  focusedLabelId: string | null,
-) {
-  const labelOrderById = new Map(labels.map((label, index) => [label.id, index]));
-  const laneEnds: number[] = [];
-  const laneByAnnotationId: Record<string, number> = {};
-  let maxLane = -1;
-  annotations
-    .filter((annotation) => annotation.label_id !== focusedLabelId)
-    .sort((left, right) => {
-      if (left.start !== right.start) {
-        return left.start - right.start;
-      }
-      if (left.end !== right.end) {
-        return left.end - right.end;
-      }
-      const labelDiff = (labelOrderById.get(left.label_id) ?? 0) - (labelOrderById.get(right.label_id) ?? 0);
-      if (labelDiff !== 0) {
-        return labelDiff;
-      }
-      return left.id.localeCompare(right.id);
-    })
-    .forEach((annotation) => {
-      let laneIndex = 0;
-      while (laneIndex < laneEnds.length && laneEnds[laneIndex] > annotation.start) {
-        laneIndex += 1;
-      }
-      laneEnds[laneIndex] = annotation.end;
-      laneByAnnotationId[annotation.id] = laneIndex;
-      maxLane = Math.max(maxLane, laneIndex);
-    });
-
-  return {
-    laneByAnnotationId,
-    reserveBottom:
-      maxLane >= 0 ? UNDERLINE_LANE_BASE + maxLane * UNDERLINE_LANE_PITCH + UNDERLINE_PADDING_TAIL : 0,
-  };
-}
-
-function mergeInlineRects(
-  rects: Array<{ left: number; right: number; top: number; bottom: number; width: number; height: number }>,
-) {
-  const sorted = [...rects]
-    .filter((rect) => rect.width > 0 && rect.height > 0)
-    .sort((left, right) => (left.top !== right.top ? left.top - right.top : left.left - right.left));
-  const merged: Array<{ left: number; right: number; top: number; bottom: number }> = [];
-  sorted.forEach((rect) => {
-    const last = merged[merged.length - 1];
-    const isSameLine =
-      last &&
-      Math.abs(last.top - rect.top) <= 1 &&
-      Math.abs(last.bottom - rect.bottom) <= 1 &&
-      rect.left <= last.right + 2;
-    if (isSameLine) {
-      last.right = Math.max(last.right, rect.right);
-      return;
-    }
-    merged.push({
-      left: rect.left,
-      right: rect.right,
-      top: rect.top,
-      bottom: rect.bottom,
-    });
-  });
-  return merged;
 }
 
 export function DocumentCanvas({
@@ -182,16 +73,11 @@ export function DocumentCanvas({
   const [markerTooltip, setMarkerTooltip] = useState<{ text: string; color: string; top: number; left: number } | null>(
     null,
   );
-  const [markerBoxes, setMarkerBoxes] = useState<
-    Array<{ annotationId: string; left: number; top: number; width: number; height: number; color: string }>
-  >([]);
-  const [overlayLines, setOverlayLines] = useState<
-    Array<{ annotationId: string; left: number; top: number; width: number; color: string }>
-  >([]);
-  const [selectionBoxes, setSelectionBoxes] = useState<
-    Array<{ left: number; top: number; width: number; height: number; color: string }>
-  >([]);
+  const [markerBoxes, setMarkerBoxes] = useState<MarkerBox[]>([]);
+  const [overlayLines, setOverlayLines] = useState<OverlayLine[]>([]);
+  const [selectionBoxes, setSelectionBoxes] = useState<SelectionBox[]>([]);
   const [layoutRevision, setLayoutRevision] = useState(0);
+  const annotationById = useMemo(() => buildAnnotationById(document.annotations), [document.annotations]);
   const labelsById = useMemo(() => new Map(labels.map((label) => [label.id, label])), [labels]);
   const underlineLayout = useMemo(
     () => buildUnderlineLaneByAnnotation(document.annotations, labels, focusedLabelId),
@@ -291,25 +177,14 @@ export function DocumentCanvas({
     const baseRect = canvas?.getBoundingClientRect() ?? root.getBoundingClientRect();
     const canvasScrollLeft = canvas?.scrollLeft ?? 0;
     const canvasScrollTop = canvas?.scrollTop ?? 0;
-    const rectsByAnnotationId: Record<
-      string,
-      Array<{ left: number; right: number; top: number; bottom: number; width: number; height: number }>
-    > = {};
-    const segmentsWithCover = root.querySelectorAll<HTMLElement>("[data-cover-ann-ids]");
-    segmentsWithCover.forEach((element) => {
-      const coverIds = (element.dataset.coverAnnIds ?? "").split(",").filter(Boolean);
-      const rects = Array.from(element.getClientRects()).map((rect) => ({
-        left: rect.left,
-        right: rect.right,
-        top: rect.top,
-        bottom: rect.bottom,
-        width: rect.width,
-        height: rect.height,
-      }));
-      coverIds.forEach((annotationId) => {
-        rectsByAnnotationId[annotationId] = [...(rectsByAnnotationId[annotationId] ?? []), ...rects];
-      });
-    });
+    const rectsByAnnotationId = buildRectsByAnnotationId(root, document.annotations);
+    const viewportOverscan = 400;
+    const viewport = {
+      left: canvasScrollLeft - viewportOverscan,
+      top: canvasScrollTop - viewportOverscan,
+      right: canvasScrollLeft + (canvas?.clientWidth ?? Number.POSITIVE_INFINITY) + viewportOverscan,
+      bottom: canvasScrollTop + (canvas?.clientHeight ?? Number.POSITIVE_INFINITY) + viewportOverscan,
+    };
 
     const nextMarkerBoxes = document.annotations
       .filter((annotation) => annotation.label_id === focusedLabelId)
@@ -325,7 +200,7 @@ export function DocumentCanvas({
           height: Math.max(18, rect.bottom - rect.top + 2),
         }));
       })
-      .filter((box) => box.width > 0);
+      .filter((box) => box.width > 0 && isBoxInViewport(box, viewport));
 
     const nextOverlayLines = document.annotations
       .filter((annotation) => annotation.label_id !== focusedLabelId)
@@ -345,11 +220,11 @@ export function DocumentCanvas({
             (UNDERLINE_LANE_BASE + (laneIndex ?? 0) * UNDERLINE_LANE_PITCH - UNDERLINE_HIT_HEIGHT / 2),
         }));
       })
-      .filter((line) => line.width > 0);
+      .filter((line) => line.width > 0 && isBoxInViewport({ ...line, height: UNDERLINE_HIT_HEIGHT }, viewport));
 
     const nextSelectionBoxes = selectedAnnotationId
       ? mergeInlineRects(rectsByAnnotationId[selectedAnnotationId] ?? []).map((rect) => {
-          const selectedAnnotation = document.annotations.find((item) => item.id === selectedAnnotationId);
+          const selectedAnnotation = annotationById.get(selectedAnnotationId);
           const selectedLabel = selectedAnnotation ? labelsById.get(selectedAnnotation.label_id) : null;
           return {
             left: rect.left - baseRect.left + canvasScrollLeft,
@@ -359,15 +234,25 @@ export function DocumentCanvas({
             color: mixColorWithBlack(selectedLabel?.color ?? "#1a73e8", 0.5),
           };
         })
+        .filter((box) => isBoxInViewport(box, viewport))
       : [];
 
-    setMarkerBoxes(nextMarkerBoxes);
-    setOverlayLines(nextOverlayLines);
-    setSelectionBoxes(nextSelectionBoxes);
-  }, [document, focusedLabelId, layoutRevision, labelsById, selectedAnnotationId, segments, underlineLayout]);
+    setMarkerBoxes((current) => (areOverlayItemsEqual(current, nextMarkerBoxes) ? current : nextMarkerBoxes));
+    setOverlayLines((current) => (areOverlayItemsEqual(current, nextOverlayLines) ? current : nextOverlayLines));
+    setSelectionBoxes((current) => (areOverlayItemsEqual(current, nextSelectionBoxes) ? current : nextSelectionBoxes));
+  }, [
+    annotationById,
+    document.annotations,
+    focusedLabelId,
+    labelsById,
+    layoutRevision,
+    selectedAnnotationId,
+    segments,
+    underlineLayout,
+  ]);
 
   const moveLaneTooltip = (annotationId: string, clientX: number, clientY: number) => {
-    const annotation = document.annotations.find((item) => item.id === annotationId);
+    const annotation = annotationById.get(annotationId);
     const label = annotation ? labelsById.get(annotation.label_id) : null;
     if (!annotation || !label) {
       setLaneTooltip(null);
@@ -382,7 +267,7 @@ export function DocumentCanvas({
   };
 
   const moveMarkerTooltip = (annotationId: string) => {
-    const annotation = document.annotations.find((item) => item.id === annotationId);
+    const annotation = annotationById.get(annotationId);
     const label = annotation ? labelsById.get(annotation.label_id) : null;
     const canvas = canvasRef.current;
     const rootRect = canvas?.getBoundingClientRect() ?? textRef.current?.getBoundingClientRect();
@@ -510,7 +395,6 @@ export function DocumentCanvas({
                   key={segment.id}
                   component="span"
                   data-primary-ann-id={primaryFocused?.id ?? ""}
-                  data-cover-ann-ids={segment.covers.map((annotation) => annotation.id).join(",")}
                   onClick={(event) => {
                     event.stopPropagation();
                     if (selectionJustCommitted()) {
@@ -590,7 +474,7 @@ export function DocumentCanvas({
                   onMouseMove={(event) => moveLaneTooltip(line.annotationId, event.clientX, event.clientY)}
                   onClick={(event) => {
                     event.stopPropagation();
-                    const annotation = document.annotations.find((item) => item.id === line.annotationId);
+                    const annotation = annotationById.get(line.annotationId);
                     if (!annotation) {
                       return;
                     }

--- a/frontend/src/components/documentCanvasLayout.ts
+++ b/frontend/src/components/documentCanvasLayout.ts
@@ -1,0 +1,294 @@
+import type { AnnotationRecord, LabelRecord } from "../api-contract";
+
+export const UNDERLINE_LANE_BASE = 5.0;
+export const UNDERLINE_LANE_PITCH = 4.4;
+export const UNDERLINE_PADDING_TAIL = 5;
+export const UNDERLINE_HIT_HEIGHT = 5;
+
+export type TextSegment = {
+  id: string;
+  start: number;
+  end: number;
+  text: string;
+  covers: AnnotationRecord[];
+  focused: AnnotationRecord[];
+  selected: boolean;
+};
+
+export type InlineRect = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+};
+
+export type MergedInlineRect = Pick<InlineRect, "left" | "right" | "top" | "bottom">;
+
+type TextNodeEntry = {
+  node: Text;
+  start: number;
+  end: number;
+};
+
+export function getSelectionOffset(container: HTMLElement, node: Node, offset: number) {
+  let total = 0;
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  while (walker.nextNode()) {
+    const currentNode = walker.currentNode;
+    const length = currentNode.textContent?.length ?? 0;
+    if (currentNode === node) {
+      return total + offset;
+    }
+    total += length;
+  }
+  return total;
+}
+
+export function mixColorWithBlack(hexColor: string, ratio = 0.5) {
+  const normalized = hexColor.replace("#", "");
+  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) {
+    return "#1d1d1d";
+  }
+  const channels = [0, 2, 4].map((offset) => Number.parseInt(normalized.slice(offset, offset + 2), 16));
+  const mixed = channels.map((channel) => Math.round(channel * (1 - ratio)));
+  return `rgb(${mixed[0]}, ${mixed[1]}, ${mixed[2]})`;
+}
+
+export function buildAnnotationById(annotations: AnnotationRecord[]) {
+  return new Map(annotations.map((annotation) => [annotation.id, annotation]));
+}
+
+function createAnnotationOrderById(annotations: AnnotationRecord[]) {
+  return new Map(annotations.map((annotation, index) => [annotation.id, index]));
+}
+
+function appendAnnotationAtOffset(
+  annotationsByOffset: Map<number, AnnotationRecord[]>,
+  offset: number,
+  annotation: AnnotationRecord,
+) {
+  const annotations = annotationsByOffset.get(offset);
+  if (annotations) {
+    annotations.push(annotation);
+    return;
+  }
+  annotationsByOffset.set(offset, [annotation]);
+}
+
+function sortByOriginalAnnotationOrder(
+  annotations: AnnotationRecord[],
+  annotationOrderById: Map<string, number>,
+) {
+  annotations.sort(
+    (left, right) => (annotationOrderById.get(left.id) ?? 0) - (annotationOrderById.get(right.id) ?? 0),
+  );
+}
+
+export function buildSegments(
+  text: string,
+  annotations: AnnotationRecord[],
+  focusedLabelId: string | null,
+  selectedAnnotationId: string | null,
+) {
+  const boundaries = new Set<number>([0, text.length]);
+  const startsByOffset = new Map<number, AnnotationRecord[]>();
+  const endsByOffset = new Map<number, AnnotationRecord[]>();
+  annotations.forEach((annotation) => {
+    boundaries.add(annotation.start);
+    boundaries.add(annotation.end);
+    appendAnnotationAtOffset(startsByOffset, annotation.start, annotation);
+    appendAnnotationAtOffset(endsByOffset, annotation.end, annotation);
+  });
+
+  const sortedBoundaries = [...boundaries].sort((a, b) => a - b);
+  const activeById = new Map<string, AnnotationRecord>();
+  const annotationOrderById = createAnnotationOrderById(annotations);
+  const segments: TextSegment[] = [];
+
+  for (let index = 0; index < sortedBoundaries.length - 1; index += 1) {
+    const start = sortedBoundaries[index];
+    const end = sortedBoundaries[index + 1];
+
+    endsByOffset.get(start)?.forEach((annotation) => {
+      activeById.delete(annotation.id);
+    });
+    startsByOffset.get(start)?.forEach((annotation) => {
+      activeById.set(annotation.id, annotation);
+    });
+
+    if (start === end) {
+      continue;
+    }
+
+    const covers = [...activeById.values()];
+    sortByOriginalAnnotationOrder(covers, annotationOrderById);
+    segments.push({
+      id: `${start}-${end}`,
+      start,
+      end,
+      text: text.slice(start, end),
+      covers,
+      focused: covers.filter((annotation) => annotation.label_id === focusedLabelId),
+      selected: covers.some((annotation) => annotation.id === selectedAnnotationId),
+    });
+  }
+
+  return segments;
+}
+
+export function buildUnderlineLaneByAnnotation(
+  annotations: AnnotationRecord[],
+  labels: LabelRecord[],
+  focusedLabelId: string | null,
+) {
+  const labelOrderById = new Map(labels.map((label, index) => [label.id, index]));
+  const laneEnds: number[] = [];
+  const laneByAnnotationId: Record<string, number> = {};
+  let maxLane = -1;
+  annotations
+    .filter((annotation) => annotation.label_id !== focusedLabelId)
+    .sort((left, right) => {
+      if (left.start !== right.start) {
+        return left.start - right.start;
+      }
+      if (left.end !== right.end) {
+        return left.end - right.end;
+      }
+      const labelDiff = (labelOrderById.get(left.label_id) ?? 0) - (labelOrderById.get(right.label_id) ?? 0);
+      if (labelDiff !== 0) {
+        return labelDiff;
+      }
+      return left.id.localeCompare(right.id);
+    })
+    .forEach((annotation) => {
+      let laneIndex = 0;
+      while (laneIndex < laneEnds.length && laneEnds[laneIndex] > annotation.start) {
+        laneIndex += 1;
+      }
+      laneEnds[laneIndex] = annotation.end;
+      laneByAnnotationId[annotation.id] = laneIndex;
+      maxLane = Math.max(maxLane, laneIndex);
+    });
+
+  return {
+    laneByAnnotationId,
+    reserveBottom:
+      maxLane >= 0 ? UNDERLINE_LANE_BASE + maxLane * UNDERLINE_LANE_PITCH + UNDERLINE_PADDING_TAIL : 0,
+  };
+}
+
+export function mergeInlineRects(rects: InlineRect[]) {
+  const sorted = [...rects]
+    .filter((rect) => rect.width > 0 && rect.height > 0)
+    .sort((left, right) => (left.top !== right.top ? left.top - right.top : left.left - right.left));
+  const merged: MergedInlineRect[] = [];
+  sorted.forEach((rect) => {
+    const last = merged[merged.length - 1];
+    const isSameLine =
+      last &&
+      Math.abs(last.top - rect.top) <= 1 &&
+      Math.abs(last.bottom - rect.bottom) <= 1 &&
+      rect.left <= last.right + 2;
+    if (isSameLine) {
+      last.right = Math.max(last.right, rect.right);
+      return;
+    }
+    merged.push({
+      left: rect.left,
+      right: rect.right,
+      top: rect.top,
+      bottom: rect.bottom,
+    });
+  });
+  return merged;
+}
+
+export function collectTextNodeIndex(container: HTMLElement) {
+  const entries: TextNodeEntry[] = [];
+  let offset = 0;
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  while (walker.nextNode()) {
+    const node = walker.currentNode as Text;
+    const length = node.textContent?.length ?? 0;
+    entries.push({ node, start: offset, end: offset + length });
+    offset += length;
+  }
+  return entries;
+}
+
+function findTextPosition(entries: TextNodeEntry[], offset: number) {
+  if (entries.length === 0) {
+    return null;
+  }
+
+  let low = 0;
+  let high = entries.length - 1;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const entry = entries[middle];
+    if (offset < entry.start) {
+      high = middle - 1;
+      continue;
+    }
+    if (offset > entry.end || (offset === entry.end && offset !== entry.start && middle < entries.length - 1)) {
+      low = middle + 1;
+      continue;
+    }
+    return { node: entry.node, offset: offset - entry.start };
+  }
+
+  const last = entries[entries.length - 1];
+  if (offset >= last.end) {
+    return { node: last.node, offset: last.node.textContent?.length ?? 0 };
+  }
+  return null;
+}
+
+export function getTextRectsForOffsetRange(
+  entries: TextNodeEntry[],
+  start: number,
+  end: number,
+): InlineRect[] {
+  const startPosition = findTextPosition(entries, start);
+  const endPosition = findTextPosition(entries, end);
+  if (!startPosition || !endPosition || start >= end) {
+    return [];
+  }
+
+  const range = document.createRange();
+  range.setStart(startPosition.node, startPosition.offset);
+  range.setEnd(endPosition.node, endPosition.offset);
+  if (typeof range.getClientRects !== "function") {
+    range.detach();
+    return [];
+  }
+  const rects = Array.from(range.getClientRects()).map((rect) => ({
+    left: rect.left,
+    right: rect.right,
+    top: rect.top,
+    bottom: rect.bottom,
+    width: rect.width,
+    height: rect.height,
+  }));
+  range.detach();
+  return rects;
+}
+
+export function buildRectsByAnnotationId(root: HTMLElement, annotations: AnnotationRecord[]) {
+  const textNodeIndex = collectTextNodeIndex(root);
+  const rectsByAnnotationId: Record<string, InlineRect[]> = {};
+  annotations.forEach((annotation) => {
+    rectsByAnnotationId[annotation.id] = getTextRectsForOffsetRange(textNodeIndex, annotation.start, annotation.end);
+  });
+  return rectsByAnnotationId;
+}
+
+export function isBoxInViewport(
+  box: { left: number; top: number; width: number; height?: number },
+  viewport: { left: number; top: number; right: number; bottom: number },
+) {
+  const height = box.height ?? 1;
+  return box.left + box.width >= viewport.left && box.left <= viewport.right && box.top + height >= viewport.top && box.top <= viewport.bottom;
+}

--- a/frontend/src/test/documentCanvasLayout.test.ts
+++ b/frontend/src/test/documentCanvasLayout.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AnnotationRecord, LabelRecord } from "../api-contract";
+import {
+  buildAnnotationById,
+  buildSegments,
+  buildUnderlineLaneByAnnotation,
+  collectTextNodeIndex,
+  getSelectionOffset,
+  getTextRectsForOffsetRange,
+  isBoxInViewport,
+  mergeInlineRects,
+} from "../components/documentCanvasLayout";
+
+const label: LabelRecord = {
+  id: "label-1",
+  project_id: "project-1",
+  project_name: "Project 1",
+  name: "Label 1",
+  color: "#3366ff",
+  description: "",
+  shortcut: "1",
+  meta: {},
+};
+
+const secondaryLabel: LabelRecord = {
+  ...label,
+  id: "label-2",
+  name: "Label 2",
+  color: "#33aa66",
+  shortcut: "2",
+};
+
+function makeAnnotation(
+  id: string,
+  start: number,
+  end: number,
+  labelId = label.id,
+): AnnotationRecord {
+  return {
+    id,
+    document_id: "doc-1",
+    document_name: "Document 1",
+    label_id: labelId,
+    label_name: labelId,
+    start,
+    end,
+    span_text: "",
+    comment: "",
+    status: "pending",
+    meta: {},
+  };
+}
+
+describe("document canvas layout helpers", () => {
+  it("builds segments while preserving original annotation order for overlaps", () => {
+    const annotations = [
+      makeAnnotation("ann-b", 2, 8, label.id),
+      makeAnnotation("ann-a", 0, 5, label.id),
+      makeAnnotation("ann-c", 4, 10, secondaryLabel.id),
+    ];
+
+    const segments = buildSegments("abcdefghij", annotations, label.id, "ann-b");
+
+    expect(segments.map((segment) => [segment.start, segment.end, segment.covers.map((item) => item.id)])).toEqual([
+      [0, 2, ["ann-a"]],
+      [2, 4, ["ann-b", "ann-a"]],
+      [4, 5, ["ann-b", "ann-a", "ann-c"]],
+      [5, 8, ["ann-b", "ann-c"]],
+      [8, 10, ["ann-c"]],
+    ]);
+    expect(segments[1].focused.map((annotation) => annotation.id)).toEqual(["ann-b", "ann-a"]);
+    expect(segments[1].selected).toBe(true);
+  });
+
+  it("keeps segment generation stable for larger synthetic inputs", () => {
+    const text = "x".repeat(500);
+    const annotations = Array.from({ length: 120 }, (_, index) => {
+      const start = index * 3;
+      return makeAnnotation(
+        `ann-${index}`,
+        start,
+        Math.min(text.length, start + 25),
+        index % 2 ? label.id : secondaryLabel.id,
+      );
+    });
+
+    const segments = buildSegments(text, annotations, label.id, "ann-10");
+
+    expect(segments[0].start).toBe(0);
+    expect(segments[segments.length - 1]?.end).toBe(text.length);
+    expect(segments.every((segment) => segment.start < segment.end)).toBe(true);
+    expect(segments.find((segment) => segment.selected)?.covers.some((annotation) => annotation.id === "ann-10")).toBe(
+      true,
+    );
+  });
+
+  it("resolves offsets across split text nodes", () => {
+    const root = document.createElement("div");
+    root.innerHTML = "<span>abc</span><span>de</span><span> fg</span>";
+    document.body.append(root);
+
+    const originalGetClientRects = Range.prototype.getClientRects;
+    const getClientRects = vi.fn(function getClientRects(this: Range) {
+      expect(this.toString()).toBe("cde ");
+      return [
+        { left: 1, right: 11, top: 2, bottom: 6, width: 10, height: 4 },
+      ] as unknown as DOMRectList;
+    });
+    Object.defineProperty(Range.prototype, "getClientRects", {
+      configurable: true,
+      value: getClientRects,
+    });
+
+    try {
+      const entries = collectTextNodeIndex(root);
+      const firstTextNode = root.querySelector("span")?.firstChild;
+
+      expect(firstTextNode).toBeTruthy();
+      expect(getSelectionOffset(root, firstTextNode as Node, 2)).toBe(2);
+      expect(getTextRectsForOffsetRange(entries, 2, 6)).toEqual([
+        { left: 1, right: 11, top: 2, bottom: 6, width: 10, height: 4 },
+      ]);
+      expect(getClientRects).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(Range.prototype, "getClientRects", {
+        configurable: true,
+        value: originalGetClientRects,
+      });
+      root.remove();
+    }
+  });
+
+  it("builds lookup and underline lane helpers without changing established ordering", () => {
+    const annotations = [
+      makeAnnotation("ann-1", 0, 8, secondaryLabel.id),
+      makeAnnotation("ann-2", 2, 6, secondaryLabel.id),
+      makeAnnotation("ann-3", 8, 12, label.id),
+    ];
+
+    expect(buildAnnotationById(annotations).get("ann-2")?.start).toBe(2);
+    expect(buildUnderlineLaneByAnnotation(annotations, [label, secondaryLabel], label.id).laneByAnnotationId).toEqual({
+      "ann-1": 0,
+      "ann-2": 1,
+    });
+  });
+
+  it("merges inline rects and filters viewport boxes", () => {
+    expect(
+      mergeInlineRects([
+        { left: 1, right: 5, top: 2, bottom: 10, width: 4, height: 8 },
+        { left: 5.5, right: 9, top: 2.5, bottom: 10.5, width: 3.5, height: 8 },
+        { left: 1, right: 4, top: 20, bottom: 28, width: 3, height: 8 },
+      ]),
+    ).toEqual([
+      { left: 1, right: 9, top: 2, bottom: 10 },
+      { left: 1, right: 4, top: 20, bottom: 28 },
+    ]);
+    expect(isBoxInViewport({ left: 10, top: 10, width: 5, height: 5 }, { left: 0, top: 0, right: 20, bottom: 20 })).toBe(
+      true,
+    );
+    expect(
+      isBoxInViewport({ left: 30, top: 10, width: 5, height: 5 }, { left: 0, top: 0, right: 20, bottom: 20 }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

- `DocumentCanvas` のspan分割とannotation重なり判定をhelperへ分離し、sweep line方式で計算するように変更
- annotation参照とoverlay rect生成をMap/Rangeベースに整理し、不要なDOM属性集計と再描画を削減
- 主要な変換処理に回帰テストを追加

## 確認

- `cd frontend && npm test`
- `cd frontend && npm run build`

Closes #41