### PR TITLE
Doc アノテーション一覧の空グループを非表示にする

### DIFF
--- a/docs/frontend/workspace-spec.md
+++ b/docs/frontend/workspace-spec.md
@@ -119,6 +119,8 @@
   - Comment / Meta カード: 「選択中 Annotation」に紐づく `status` / `comment` / `meta` を表示・編集する。必要に応じて折りたたみ可能とし、開閉 UI は Doc アノテーション一覧と同系統の三角アコーディオン表現で統一する。
   - Doc アノテーション一覧カード: 現在選択中 Doc の Annotation を Label ごとに表示する。
 - Doc アノテーション一覧は Label ごとのアコーディオン形式とする。
+- Doc アノテーション一覧には、現在選択中 Doc に Annotation が存在する Label のみ表示する。
+- 現在選択中 Doc に Annotation が存在しない場合は、一覧カード内に空状態を表示する。
 - 各 Label グループ内の Annotation は `start`（span の開始 index）昇順で表示し、同一 `start` の場合は `end` 昇順で扱う。
 - 各 Annotation 行には `status` バッジを表示する。
 - 文脈表示は前後 10 文字固定で生成し、`span_text` 以外（前後文脈）は灰色で表示する。

--- a/frontend/src/features/project-shell/WorkspaceView.tsx
+++ b/frontend/src/features/project-shell/WorkspaceView.tsx
@@ -938,15 +938,17 @@ export function WorkspaceView({
                         direction="row"
                         spacing={1}
                         alignItems="center"
-                        sx={{ cursor: "pointer", width: "fit-content" }}
+                        sx={{ cursor: "pointer", width: "100%", minWidth: 0 }}
                         onClick={() => onToggleAnnotationGroup(label.id)}
                       >
-                        <Box sx={{ width: 18, display: "grid", placeItems: "center" }}>
+                        <Box sx={{ width: 18, flexShrink: 0, display: "grid", placeItems: "center" }}>
                           <Typography variant="caption">{accordionOpen[label.id] ?? true ? "▼" : "▶"}</Typography>
                         </Box>
-                        <LabelRoundedIcon sx={{ color: label.color, fontSize: 18 }} />
-                        <Typography variant="subtitle2">{label.name}</Typography>
-                        <Chip size="small" label={annotations.length} />
+                        <LabelRoundedIcon sx={{ color: label.color, flexShrink: 0, fontSize: 18 }} />
+                        <Typography variant="subtitle2" noWrap sx={{ minWidth: 0, flex: 1 }}>
+                          {label.name}
+                        </Typography>
+                        <Chip size="small" label={annotations.length} sx={{ flexShrink: 0 }} />
                       </Stack>
                       <Stack spacing={1} sx={{ mt: 1.25, display: accordionOpen[label.id] ?? true ? "flex" : "none" }}>
                         {annotations.map((annotation) => {

--- a/frontend/src/features/project-shell/WorkspaceView.tsx
+++ b/frontend/src/features/project-shell/WorkspaceView.tsx
@@ -184,6 +184,10 @@ export function WorkspaceView({
     () => (currentDocument ? groupAnnotationsByLabel(currentDocument, bundle.labels) : []),
     [currentDocument, bundle.labels],
   );
+  const visibleAnnotationGroups = useMemo(
+    () => groupedAnnotations.filter((group) => group.annotations.length > 0),
+    [groupedAnnotations],
+  );
   const { t } = useI18n();
   const [hoveredDocumentId, setHoveredDocumentId] = useState<string | null>(null);
   const [focusedDocumentId, setFocusedDocumentId] = useState<string | null>(null);
@@ -924,8 +928,11 @@ export function WorkspaceView({
 
               <Paper variant="outlined" sx={{ p: 2, display: "flex", flexDirection: "column", minHeight: 0, overflow: "hidden" }}>
                 <Typography variant="subtitle2">{t("projectShell.workspace.documentAnnotationsTitle")}</Typography>
-                <Stack spacing={1.5} sx={{ mt: 1.5, overflow: "auto", minHeight: 0, pr: 0.5 }}>
-                  {groupedAnnotations.map(({ label, annotations }) => (
+                <Stack data-testid="document-annotation-list" spacing={1.5} sx={{ mt: 1.5, overflow: "auto", minHeight: 0, pr: 0.5 }}>
+                  {currentDocument && visibleAnnotationGroups.length === 0 ? (
+                    <Typography color="text.secondary">{t("projectShell.workspace.noAnnotations")}</Typography>
+                  ) : null}
+                  {visibleAnnotationGroups.map(({ label, annotations }) => (
                     <Paper key={label.id} variant="outlined" sx={{ p: 1.5 }}>
                       <Stack
                         direction="row"
@@ -985,7 +992,6 @@ export function WorkspaceView({
                             </Paper>
                           );
                         })}
-                        {annotations.length === 0 ? <Typography color="text.secondary">{t("projectShell.workspace.noAnnotations")}</Typography> : null}
                       </Stack>
                     </Paper>
                   ))}

--- a/frontend/src/test/workspaceView.test.tsx
+++ b/frontend/src/test/workspaceView.test.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { WorkspaceView } from "../features/project-shell/WorkspaceView";
 import type { SelectionPreview } from "../features/project-shell/projectShellTypes";
@@ -344,6 +344,42 @@ describe("WorkspaceView", () => {
     } finally {
       window.HTMLElement.prototype.scrollIntoView = original;
     }
+  });
+
+  it("hides label groups without annotations in the document annotation list", () => {
+    render(
+      <WorkspaceView
+        {...createProps({
+          bundle: { project, labels: [label, secondaryLabel], documents: [] },
+          currentDocument: annotationCurrentDocument,
+          rightTab: "annotations",
+        })}
+      />,
+    );
+
+    const annotationList = within(screen.getByTestId("document-annotation-list"));
+
+    expect(annotationList.getByText("主訴")).toBeInTheDocument();
+    expect(annotationList.queryByText("所見")).not.toBeInTheDocument();
+    expect(annotationList.queryByText("Annotation なし")).not.toBeInTheDocument();
+  });
+
+  it("shows an empty state when the current document has no annotations", () => {
+    render(
+      <WorkspaceView
+        {...createProps({
+          bundle: { project, labels: [label, secondaryLabel], documents: [] },
+          currentDocument: { ...annotationCurrentDocument, annotations: [] },
+          rightTab: "annotations",
+        })}
+      />,
+    );
+
+    const annotationList = within(screen.getByTestId("document-annotation-list"));
+
+    expect(annotationList.getByText("Annotation なし")).toBeInTheDocument();
+    expect(annotationList.queryByText("主訴")).not.toBeInTheDocument();
+    expect(annotationList.queryByText("所見")).not.toBeInTheDocument();
   });
 
   it("splits the remaining examples area equally between the same-label and same-surface panels", () => {


### PR DESCRIPTION
## 概要
- Doc アノテーション一覧で、現在の Doc に Annotation が存在する Label group のみ表示するように変更
- Annotation が存在しない Doc では、一覧カード内に空状態を表示
- Workspace 仕様と回帰テストを更新

## 確認
- `npm test -- workspaceView.test.tsx`
- `npm test`
- `npm run build`

Closes #54