### PR TITLE
ラベル表示順の保存と並び替え UI を実装する

### DIFF
--- a/backend/src/layered_span_studio_backend/repositories/bulk_import.py
+++ b/backend/src/layered_span_studio_backend/repositories/bulk_import.py
@@ -4,6 +4,7 @@ import uuid
 from typing import Any, Dict, List
 
 from layered_span_studio_backend.core.config import Settings
+from layered_span_studio_backend.repositories.label_sync import next_label_display_order
 from layered_span_studio_backend.repositories.projects import project_db_path
 from layered_span_studio_backend.storage.project_db import (
     annotations_table,
@@ -89,6 +90,9 @@ def import_entities(
             )
 
     with engine.begin() as conn:
+        next_display_order = next_label_display_order(conn, project_id)
+        for index, label_row in enumerate(label_rows):
+            label_row["display_order"] = next_display_order + index
         if label_rows:
             conn.execute(labels_table.insert(), label_rows)
         if document_rows:

--- a/backend/src/layered_span_studio_backend/repositories/label_sync.py
+++ b/backend/src/layered_span_studio_backend/repositories/label_sync.py
@@ -11,15 +11,28 @@ from layered_span_studio_backend.storage.project_db import labels_table
 from layered_span_studio_backend.utils.json_utils import encode_meta
 
 
-def ensure_label_display_order_column(conn: Connection, project_id: str | None = None) -> None:
+def _ensure_display_order_column_exists(conn: Connection) -> None:
     columns = {row["name"] for row in conn.exec_driver_sql("PRAGMA table_info(labels)").mappings()}
-    if "display_order" not in columns:
-        try:
-            conn.exec_driver_sql("ALTER TABLE labels ADD COLUMN display_order INTEGER")
-        except OperationalError as exc:
-            if "duplicate column name" not in str(exc).lower():
-                raise
+    if "display_order" in columns:
+        return
+    try:
+        conn.exec_driver_sql("ALTER TABLE labels ADD COLUMN display_order INTEGER")
+    except OperationalError as exc:
+        if "duplicate column name" not in str(exc).lower():
+            raise
 
+
+def _current_max_display_order(conn: Connection, project_id: str) -> int | None:
+    current_max = conn.execute(
+        select(func.max(labels_table.c.display_order)).where(
+            labels_table.c.project_id == project_id,
+            labels_table.c.display_order.is_not(None),
+        )
+    ).scalar_one()
+    return int(current_max) if current_max is not None else None
+
+
+def _backfill_missing_display_orders(conn: Connection, project_id: str | None = None) -> None:
     query = select(labels_table).where(labels_table.c.display_order.is_(None))
     if project_id is not None:
         query = query.where(labels_table.c.project_id == project_id)
@@ -28,13 +41,8 @@ def ensure_label_display_order_column(conn: Connection, project_id: str | None =
     for row in rows:
         row_project_id = row["project_id"]
         if row_project_id not in next_order_by_project:
-            current_max = conn.execute(
-                select(func.max(labels_table.c.display_order)).where(
-                    labels_table.c.project_id == row_project_id,
-                    labels_table.c.display_order.is_not(None),
-                )
-            ).scalar_one()
-            next_order_by_project[row_project_id] = int(current_max) + 1 if current_max is not None else 0
+            current_max = _current_max_display_order(conn, row_project_id)
+            next_order_by_project[row_project_id] = current_max + 1 if current_max is not None else 0
         display_order = next_order_by_project[row_project_id]
         conn.execute(
             labels_table.update()
@@ -44,12 +52,15 @@ def ensure_label_display_order_column(conn: Connection, project_id: str | None =
         next_order_by_project[row_project_id] = display_order + 1
 
 
+def ensure_label_display_order_column(conn: Connection, project_id: str | None = None) -> None:
+    _ensure_display_order_column_exists(conn)
+    _backfill_missing_display_orders(conn, project_id)
+
+
 def next_label_display_order(conn: Connection, project_id: str) -> int:
     ensure_label_display_order_column(conn, project_id)
-    current_max = conn.execute(
-        select(func.max(labels_table.c.display_order)).where(labels_table.c.project_id == project_id)
-    ).scalar_one()
-    return int(current_max) + 1 if current_max is not None else 0
+    current_max = _current_max_display_order(conn, project_id)
+    return current_max + 1 if current_max is not None else 0
 
 
 def load_label_rows(conn: Connection, project_id: str) -> Sequence[RowMapping]:

--- a/backend/src/layered_span_studio_backend/repositories/label_sync.py
+++ b/backend/src/layered_span_studio_backend/repositories/label_sync.py
@@ -33,7 +33,7 @@ def _current_max_display_order(conn: Connection, project_id: str) -> int | None:
 
 
 def _backfill_missing_display_orders(conn: Connection, project_id: str | None = None) -> None:
-    query = select(labels_table).where(labels_table.c.display_order.is_(None))
+    query = select(labels_table.c.id, labels_table.c.project_id).where(labels_table.c.display_order.is_(None))
     if project_id is not None:
         query = query.where(labels_table.c.project_id == project_id)
     rows = conn.execute(query.order_by(labels_table.c.name.asc(), labels_table.c.id.asc())).mappings().all()

--- a/backend/src/layered_span_studio_backend/repositories/label_sync.py
+++ b/backend/src/layered_span_studio_backend/repositories/label_sync.py
@@ -3,18 +3,61 @@ from __future__ import annotations
 import uuid
 from typing import Any, Dict, List, Sequence
 
-from sqlalchemy import select
+from sqlalchemy import func, select
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.engine import Connection, RowMapping
 
 from layered_span_studio_backend.storage.project_db import labels_table
 from layered_span_studio_backend.utils.json_utils import encode_meta
 
 
+def ensure_label_display_order_column(conn: Connection, project_id: str | None = None) -> None:
+    columns = {row["name"] for row in conn.exec_driver_sql("PRAGMA table_info(labels)").mappings()}
+    if "display_order" not in columns:
+        try:
+            conn.exec_driver_sql("ALTER TABLE labels ADD COLUMN display_order INTEGER")
+        except OperationalError as exc:
+            if "duplicate column name" not in str(exc).lower():
+                raise
+
+    query = select(labels_table).where(labels_table.c.display_order.is_(None))
+    if project_id is not None:
+        query = query.where(labels_table.c.project_id == project_id)
+    rows = conn.execute(query.order_by(labels_table.c.name.asc(), labels_table.c.id.asc())).mappings().all()
+    next_order_by_project: dict[str, int] = {}
+    for row in rows:
+        row_project_id = row["project_id"]
+        if row_project_id not in next_order_by_project:
+            current_max = conn.execute(
+                select(func.max(labels_table.c.display_order)).where(
+                    labels_table.c.project_id == row_project_id,
+                    labels_table.c.display_order.is_not(None),
+                )
+            ).scalar_one()
+            next_order_by_project[row_project_id] = int(current_max) + 1 if current_max is not None else 0
+        display_order = next_order_by_project[row_project_id]
+        conn.execute(
+            labels_table.update()
+            .where(labels_table.c.id == row["id"])
+            .values(display_order=display_order)
+        )
+        next_order_by_project[row_project_id] = display_order + 1
+
+
+def next_label_display_order(conn: Connection, project_id: str) -> int:
+    ensure_label_display_order_column(conn, project_id)
+    current_max = conn.execute(
+        select(func.max(labels_table.c.display_order)).where(labels_table.c.project_id == project_id)
+    ).scalar_one()
+    return int(current_max) + 1 if current_max is not None else 0
+
+
 def load_label_rows(conn: Connection, project_id: str) -> Sequence[RowMapping]:
+    ensure_label_display_order_column(conn, project_id)
     return conn.execute(
         select(labels_table)
         .where(labels_table.c.project_id == project_id)
-        .order_by(labels_table.c.name.asc(), labels_table.c.id.asc())
+        .order_by(labels_table.c.display_order.asc(), labels_table.c.name.asc(), labels_table.c.id.asc())
     ).mappings().all()
 
 
@@ -24,6 +67,7 @@ def sync_labels(
     items: List[Dict[str, Any]],
     existing_rows: Sequence[RowMapping] | None = None,
 ) -> None:
+    ensure_label_display_order_column(conn, project_id)
     rows = list(existing_rows) if existing_rows is not None else list(load_label_rows(conn, project_id))
     existing_ids = {row["id"] for row in rows}
     requested_ids = {item["id"] for item in items if item.get("id")}
@@ -40,7 +84,7 @@ def sync_labels(
             )
         )
 
-    for item in items:
+    for display_order, item in enumerate(items):
         label_id = item.get("id")
         if label_id:
             conn.execute(
@@ -55,6 +99,7 @@ def sync_labels(
                     description=item["description"],
                     shortcut=item.get("shortcut"),
                     meta=encode_meta(item.get("meta")),
+                    display_order=display_order,
                 )
             )
             continue
@@ -68,5 +113,6 @@ def sync_labels(
                 description=item["description"],
                 shortcut=item.get("shortcut"),
                 meta=encode_meta(item.get("meta")),
+                display_order=display_order,
             )
         )

--- a/backend/src/layered_span_studio_backend/repositories/labels.py
+++ b/backend/src/layered_span_studio_backend/repositories/labels.py
@@ -8,7 +8,12 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import case, func, select
 
 from layered_span_studio_backend.core.config import Settings
-from layered_span_studio_backend.repositories.label_sync import load_label_rows, sync_labels
+from layered_span_studio_backend.repositories.label_sync import (
+    ensure_label_display_order_column,
+    load_label_rows,
+    next_label_display_order,
+    sync_labels,
+)
 from layered_span_studio_backend.repositories.projects import project_db_path
 from layered_span_studio_backend.storage.project_db import (
     annotations_table,
@@ -43,6 +48,7 @@ def _labels_revision_from_rows(rows: List[Dict[str, Any]] | Any) -> str:
             "description": row["description"],
             "shortcut": row["shortcut"],
             "meta": decode_meta(row["meta"]),
+            "display_order": row["display_order"],
         }
         for row in rows
     ]
@@ -69,7 +75,7 @@ def list_labels_state(settings: Settings, project_id: str) -> Dict[str, Any]:
     db_path = project_db_path(settings, project_id)
     engine = get_project_engine(str(db_path))
     project_name = _project_name(settings, project_id)
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         rows = load_label_rows(conn, project_id)
     rows_list = list(rows)
     return {
@@ -82,7 +88,8 @@ def get_label(settings: Settings, project_id: str, label_id: str) -> Optional[Di
     db_path = project_db_path(settings, project_id)
     engine = get_project_engine(str(db_path))
     project_name = _project_name(settings, project_id)
-    with engine.connect() as conn:
+    with engine.begin() as conn:
+        ensure_label_display_order_column(conn, project_id)
         row = (
             conn.execute(
                 select(labels_table).where(
@@ -111,7 +118,8 @@ def get_label_by_name(settings: Settings, project_id: str, name: str) -> Optiona
     db_path = project_db_path(settings, project_id)
     engine = get_project_engine(str(db_path))
     project_name = _project_name(settings, project_id)
-    with engine.connect() as conn:
+    with engine.begin() as conn:
+        ensure_label_display_order_column(conn, project_id)
         row = (
             conn.execute(
                 select(labels_table).where(
@@ -150,6 +158,7 @@ def create_label(
     project_name = _project_name(settings, project_id)
     label_id = str(uuid.uuid4())
     with engine.begin() as conn:
+        display_order = next_label_display_order(conn, project_id)
         conn.execute(
             labels_table.insert().values(
                 id=label_id,
@@ -159,6 +168,7 @@ def create_label(
                 description=description,
                 shortcut=shortcut,
                 meta=encode_meta(meta),
+                display_order=display_order,
             )
         )
     return {

--- a/backend/src/layered_span_studio_backend/storage/project_db.py
+++ b/backend/src/layered_span_studio_backend/storage/project_db.py
@@ -41,6 +41,7 @@ labels_table = Table(
     Column("description", Text, nullable=False),
     Column("shortcut", String),
     Column("meta", Text),
+    Column("display_order", Integer),
 )
 
 # SQLite does not enforce foreign keys unless PRAGMA is set. We'll enable it per-connection.

--- a/backend/tests/test_import_export.py
+++ b/backend/tests/test_import_export.py
@@ -124,6 +124,53 @@ def test_import_creates_new_project_from_export(
     )
 
 
+def test_export_and_import_preserve_label_order(client: TestClient, auth_headers: dict[str, str]) -> None:
+    project = client.post(
+        "/projects", json={"name": "Project Label Order", "description": "desc"}, headers=auth_headers
+    ).json()
+    first = create_label_via_sync(client, auth_headers, project["id"], name="Zulu", color="#FF5733", description="desc")
+    second = create_label_via_sync(client, auth_headers, project["id"], name="Alpha", color="#33AA44", description="desc")
+    current = client.get(f"/projects/{project['id']}/labels", headers=auth_headers).json()
+
+    reorder_response = client.put(
+        f"/projects/{project['id']}/labels",
+        json={
+            "base_revision": current["revision"],
+            "labels": [
+                {
+                    "id": second["id"],
+                    "name": second["name"],
+                    "color": second["color"],
+                    "description": second["description"],
+                    "shortcut": second["shortcut"],
+                    "meta": second["meta"],
+                },
+                {
+                    "id": first["id"],
+                    "name": first["name"],
+                    "color": first["color"],
+                    "description": first["description"],
+                    "shortcut": first["shortcut"],
+                    "meta": first["meta"],
+                },
+            ],
+        },
+        headers=auth_headers,
+    )
+    assert reorder_response.status_code == 200
+
+    payload = _export_project_payload(client, auth_headers, project["id"])
+    assert [label["name"] for label in payload["labels"]] == ["Alpha", "Zulu"]
+    payload["project"]["name"] = "Project Label Order Imported"
+
+    import_response = client.post("/projects/import", json=payload, headers=auth_headers)
+    assert import_response.status_code == 201
+    imported_project = import_response.json()["project"]
+    labels_response = client.get(f"/projects/{imported_project['id']}/labels", headers=auth_headers)
+    assert labels_response.status_code == 200
+    assert [label["name"] for label in labels_response.json()["labels"]] == ["Alpha", "Zulu"]
+
+
 def test_import_creates_new_project_with_auto_renamed_name(
     client: TestClient, auth_headers: dict[str, str]
 ) -> None:

--- a/backend/tests/test_labels.py
+++ b/backend/tests/test_labels.py
@@ -129,6 +129,52 @@ def test_labels_put_syncs_create_update_delete(client: TestClient, auth_headers:
     assert all(label["id"] != second["id"] for label in payload)
 
 
+def test_labels_put_preserves_payload_order_and_updates_revision(
+    client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    project_id = _create_project(client, auth_headers)
+    first = create_label_via_sync(
+        client, auth_headers, project_id, name="Zulu", color="#FF5733", description="desc", shortcut="z", meta={}
+    )
+    second = create_label_via_sync(
+        client, auth_headers, project_id, name="Alpha", color="#33AA44", description="desc", shortcut="a", meta={}
+    )
+    current_payload = _get_labels_payload(client, auth_headers, project_id)
+
+    response = client.put(
+        f"/projects/{project_id}/labels",
+        json={
+            "base_revision": current_payload["revision"],
+            "labels": [
+                {
+                    "id": second["id"],
+                    "name": second["name"],
+                    "color": second["color"],
+                    "description": second["description"],
+                    "shortcut": second["shortcut"],
+                    "meta": second["meta"],
+                },
+                {
+                    "id": first["id"],
+                    "name": first["name"],
+                    "color": first["color"],
+                    "description": first["description"],
+                    "shortcut": first["shortcut"],
+                    "meta": first["meta"],
+                },
+            ],
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert [label["name"] for label in response.json()["labels"]] == ["Alpha", "Zulu"]
+    assert response.json()["revision"] != current_payload["revision"]
+
+    persisted = _get_labels_payload(client, auth_headers, project_id)
+    assert [label["name"] for label in persisted["labels"]] == ["Alpha", "Zulu"]
+
+
 def test_labels_put_rejects_duplicate_name_in_payload(client: TestClient, auth_headers: dict[str, str]) -> None:
     project_id = _create_project(client, auth_headers)
     current_payload = _get_labels_payload(client, auth_headers, project_id)

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -236,7 +236,7 @@ def test_project_settings_atomic_put_uses_same_label_order_as_labels_api(
 
     labels_response = client.get(f"/projects/{project['id']}/labels", headers=auth_headers)
     assert labels_response.status_code == 200
-    assert [label["name"] for label in labels_response.json()["labels"]] == ["Alpha", "Zulu"]
+    assert [label["name"] for label in labels_response.json()["labels"]] == ["Zulu", "Alpha"]
     assert [label["id"] for label in response.json()["labels"]] == [
         label["id"] for label in labels_response.json()["labels"]
     ]
@@ -442,6 +442,50 @@ def test_projects_list_backfills_created_at_from_legacy_project_db(
         assert "created_at" in columns
         stored_created_at = conn.execute("SELECT created_at FROM project WHERE id = ?", (project_id,)).fetchone()[0]
     assert stored_created_at == expected_created_at
+
+
+def test_labels_api_backfills_display_order_from_legacy_project_db(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    settings,
+) -> None:
+    project_id = "legacy-label-order-project"
+    project_dir = settings.projects_dir / project_id
+    project_dir.mkdir(parents=True, exist_ok=True)
+    db_path = project_dir / PROJECT_DB_FILENAME
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, meta TEXT, created_at TEXT NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE labels (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, name TEXT NOT NULL, color TEXT NOT NULL, description TEXT NOT NULL, shortcut TEXT, meta TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE documents (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, document_name TEXT NOT NULL, text TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'pending', created_at TEXT NOT NULL, updated_at TEXT NOT NULL, meta TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO project (id, name, description, meta, created_at) VALUES (?, ?, ?, ?, ?)",
+            (project_id, "Legacy Label Order Project", "desc", "{}", "2026-03-01T00:00:00Z"),
+        )
+        conn.executemany(
+            "INSERT INTO labels (id, project_id, name, color, description, shortcut, meta) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("label-z", project_id, "Zulu", "#FF5733", "desc", None, "{}"),
+                ("label-a", project_id, "Alpha", "#33AA44", "desc", None, "{}"),
+            ],
+        )
+        conn.commit()
+
+    response = client.get(f"/projects/{project_id}/labels", headers=auth_headers)
+    assert response.status_code == 200
+    assert [label["name"] for label in response.json()["labels"]] == ["Alpha", "Zulu"]
+
+    with sqlite3.connect(db_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(labels)")}
+        stored_order = conn.execute("SELECT name, display_order FROM labels ORDER BY display_order").fetchall()
+    assert "display_order" in columns
+    assert stored_order == [("Alpha", 0), ("Zulu", 1)]
 
 
 def test_projects_list_backfills_null_created_at_when_column_already_exists(

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -514,7 +514,7 @@ Authorization: Bearer <token>
 
 ### GET /projects/{project_id}/labels
 
-プロジェクトの全ラベルを取得する。
+プロジェクトの全ラベルを取得する。返却順は Project Settings で保存された label 表示順である。
 
 **Headers:**
 ```
@@ -618,6 +618,7 @@ Authorization: Bearer <token>
 **注記:**
 - `revision` は現在の label 一覧を表す 64 文字の lowercase sha256 hex digest
 - Label の作成 / 更新 / 削除は、この endpoint で最終状態全件を同期して表現する
+- request の `labels` 配列順は label 表示順として保存され、以後の `GET /projects/{project_id}/labels` と export の `labels` 配列順に反映される
 - `GET /projects/{project_id}/labels` の response に含まれる `revision` を、保存時に `base_revision` としてそのまま渡す
 - `base_revision` は 64 文字の lowercase sha256 hex digest を受け付ける
 - `id = null` は新規 label 作成

--- a/docs/backend/database-schema.md
+++ b/docs/backend/database-schema.md
@@ -181,6 +181,7 @@ CREATE TABLE labels (
     description TEXT NOT NULL,    -- ラベルの説明（ガイドライン含む）
     shortcut TEXT,                -- キーボードショートカット
     meta TEXT,                    -- JSON: 任意の拡張情報
+    display_order INTEGER,        -- Project 内の表示順
     FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE CASCADE
 );
 
@@ -197,12 +198,14 @@ CREATE INDEX idx_labels_name ON labels(name);
 | description | TEXT | NOT NULL | ラベルの説明（ガイドライン含む） |
 | shortcut | TEXT | NULL | キーボードショートカット（例: "1", "d"） |
 | meta | TEXT | NULL | 任意の拡張情報（JSON文字列） |
+| display_order | INTEGER | NULL | Project 内の表示順 |
 
 **設計ポイント**:
 - `name` は変更可能（ユーザー向け表示名）
 - `id` は不変（システム内部での識別子）
 - ラベル名を変更しても、既存のアノテーションへの参照は壊れない
- - 外部JSONでは `project_id` を持たないため、インポート時は `project.id` を補完して保存する
+- `display_order` は backend 内部の保存順であり、外部JSONでは `labels` 配列順で表現する
+- 外部JSONでは `project_id` を持たないため、インポート時は `project.id` を補完して保存する
 
 ---
 

--- a/docs/backend/json-schema.md
+++ b/docs/backend/json-schema.md
@@ -62,11 +62,13 @@
 ```
 
 - request の `labels` は project 配下 label の最終状態全件
+- request の `labels` 配列順は label 表示順として保存される
 - request の `base_revision` は直前に取得した label 一覧の revision
 - `base_revision` / response の `revision` は 64 文字の lowercase sha256 hex digest
 - `id: null` は新規 label
 - request に含まれない既存 label は削除
 - response は `labels: Label[]` と `revision`
+- response の `labels` 配列順は保存済みの label 表示順
 
 response 例:
 
@@ -263,6 +265,7 @@ response 例:
 ```
 
 - settings 画面の project フォームと label 一覧の完全現在値を表す
+- `labels` 配列順は label 表示順として保存される
 - response は次の形を返す
 
 ```json

--- a/docs/frontend/workspace-spec.md
+++ b/docs/frontend/workspace-spec.md
@@ -200,7 +200,9 @@
 
 - Project scope 共通 header では、左側に project 名と説明文、中央に `Workspace / Project Settings` 切り替え、右側に言語切替、現在の username、logout 導線をまとめて表示する。
 - Project 名と説明文を編集可能にする。
-- Label定義管理を行う（追加 / 編集 / 削除）。
+- Label定義管理を行う（追加 / 編集 / 削除 / 表示順変更）。
+- Label 表示順変更は、一覧左端のグラブハンドルを縦方向にドラッグして行う。ドラッグ中は周囲の Label 行が並び替え位置へ滑って移動するアニメーションを付ける。
+- 表示順保存後は Workspace の Label Selector、右ペインの Annotation グループ順、label 切り替えショートカット順に反映する。
 - Label削除時は対応するAnnotationも同時に除去する。
 - プロジェクトガイドライン文言を編集可能にする。
 - Import / Export カードを同画面内に配置する。

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1219,6 +1219,17 @@ export function ProjectShell({
     }
   }
 
+  function handleReorderSettingsLabel(labelId: string, targetIndex: number) {
+    mutateSettingsBundle((draft) => {
+      const index = draft.labels.findIndex((label) => label.id === labelId);
+      if (index < 0 || targetIndex < 0 || targetIndex >= draft.labels.length || index === targetIndex) {
+        return;
+      }
+      const [label] = draft.labels.splice(index, 1);
+      draft.labels.splice(targetIndex, 0, label);
+    });
+  }
+
   if (loading || !bundle) {
     return (
       <Box sx={{ minHeight: "100vh", display: "grid", placeItems: "center" }}>
@@ -1410,6 +1421,7 @@ export function ProjectShell({
                 setSelectedSettingsLabelId(labelId);
                 setLabelDraft(toLabelDraft(selectedLabel));
               }}
+              onReorderLabel={handleReorderSettingsLabel}
               onDeleteLabel={handleDeleteLabel}
               onImportFileChange={(file) => {
                 setSettingsImportFile(file);

--- a/frontend/src/features/project-shell/SettingsView.tsx
+++ b/frontend/src/features/project-shell/SettingsView.tsx
@@ -56,9 +56,38 @@ function labelRowsFromRefs(bundle: ProjectBundle, refs: Map<string, HTMLDivEleme
     .filter((item): item is LabelRowElement => Boolean(item.element));
 }
 
+function labelDragRowsFromRefs(bundle: ProjectBundle, refs: Map<string, HTMLDivElement>) {
+  return labelRowsFromRefs(bundle, refs).map((row) => {
+    const rect = row.element.getBoundingClientRect();
+    return {
+      ...row,
+      top: rect.top,
+      height: rect.height || 1,
+    };
+  });
+}
+
 function clearLabelRowStyles(rows: LabelRowElement[]) {
   for (const row of rows) {
     row.element.style.transition = "";
+    row.element.style.transform = "";
+    row.element.style.zIndex = "";
+  }
+}
+
+function setLabelRowTransform(row: LabelRowElement, deltaY: number) {
+  row.element.style.transform = deltaY === 0 ? "" : `translateY(${deltaY}px)`;
+}
+
+function setLabelRowTransitions(rows: LabelRowElement[], transition: string) {
+  for (const row of rows) {
+    row.element.style.transition = transition;
+  }
+}
+
+function resetLabelRowsForMeasurement(rows: LabelRowElement[]) {
+  for (const row of rows) {
+    row.element.style.transition = "none";
     row.element.style.transform = "";
     row.element.style.zIndex = "";
   }
@@ -95,13 +124,12 @@ function orderIdsByDragBoundaries(
   if (draggedIndex < 0) {
     return currentIds;
   }
-  const currentIndexById = new Map(currentIds.map((id, index) => [id, index]));
   const upperProbeY = draggedTop;
   const lowerProbeY = draggedTop + draggedHeight;
   const beforeDragged: string[] = [];
   const afterDragged: string[] = [];
 
-  for (const id of currentIds) {
+  for (const [currentIndex, id] of currentIds.entries()) {
     if (id === draggedId) {
       continue;
     }
@@ -111,8 +139,7 @@ function orderIdsByDragBoundaries(
       continue;
     }
     const centerY = currentTop + row.height / 2;
-    const currentIndex = currentIndexById.get(id);
-    const isCurrentlyBeforeDragged = currentIndex !== undefined && currentIndex < draggedIndex;
+    const isCurrentlyBeforeDragged = currentIndex < draggedIndex;
 
     if (isCurrentlyBeforeDragged) {
       if (centerY > upperProbeY) {
@@ -131,6 +158,42 @@ function orderIdsByDragBoundaries(
   }
 
   return [...beforeDragged, draggedId, ...afterDragged];
+}
+
+function dragBoundsForRows(rows: LabelDragRow[], draggedRow: LabelDragRow) {
+  const firstTop = Math.min(...rows.map((row) => row.top));
+  const lastBottom = Math.max(...rows.map((row) => row.top + row.height));
+  return {
+    firstTop,
+    maxDraggedTop: Math.max(firstTop, lastBottom - draggedRow.height),
+  };
+}
+
+function snapRowsToOrder(rows: LabelDragRow[], ids: string[], rowById: Map<string, LabelDragRow>, startTop: number) {
+  const targetTopById = targetTopsForOrder(ids, rowById, startTop);
+  for (const row of rows) {
+    const targetTop = targetTopById.get(row.id) ?? row.top;
+    setLabelRowTransform(row, targetTop - row.top);
+  }
+}
+
+function keepVisualPositionsAfterCommit(rows: LabelRowElement[], commitState: () => void) {
+  const visualTopById = new Map(rows.map((row) => [row.id, row.element.getBoundingClientRect().top]));
+  flushSync(commitState);
+  resetLabelRowsForMeasurement(rows);
+
+  for (const row of rows) {
+    const visualTop = visualTopById.get(row.id);
+    if (visualTop === undefined) {
+      continue;
+    }
+    const naturalTop = row.element.getBoundingClientRect().top;
+    setLabelRowTransform(row, visualTop - naturalTop);
+  }
+
+  window.requestAnimationFrame(() => {
+    clearLabelRowStyles(rows);
+  });
 }
 
 export function SettingsView({
@@ -221,14 +284,7 @@ export function SettingsView({
     if (event.pointerType === "mouse" && event.button !== 0) {
       return;
     }
-    const rows = labelRowsFromRefs(bundle, labelRowRefs.current).map((row) => {
-      const rect = row.element.getBoundingClientRect();
-      return {
-        ...row,
-        top: rect.top,
-        height: rect.height || 1,
-      };
-    });
+    const rows = labelDragRowsFromRefs(bundle, labelRowRefs.current);
     const ids = rows.map((row) => row.id);
     const from = ids.indexOf(labelId);
     const dragged = rows.find((row) => row.id === labelId);
@@ -245,9 +301,7 @@ export function SettingsView({
 
     const handle = event.currentTarget;
     const rowById = new Map(rows.map((row) => [row.id, row]));
-    const firstTop = Math.min(...rows.map((row) => row.top));
-    const lastBottom = Math.max(...rows.map((row) => row.top + row.height));
-    const maxDraggedTop = Math.max(firstTop, lastBottom - draggedRow.height);
+    const { firstTop, maxDraggedTop } = dragBoundsForRows(rows, draggedRow);
     const pointerOffsetY = event.clientY - draggedRow.top;
     let latestNextIds = ids;
     let latestClientY = event.clientY;
@@ -270,8 +324,7 @@ export function SettingsView({
           row.id === labelId && !options.snapDraggedToSlot
             ? draggedTop
             : targetTop;
-        const deltaY = visualTop - row.top;
-        row.element.style.transform = deltaY === 0 ? "" : `translateY(${deltaY}px)`;
+        setLabelRowTransform(row, visualTop - row.top);
       }
     }
 
@@ -318,45 +371,20 @@ export function SettingsView({
 
       const nextIds = commit ? latestNextIds : ids;
       const shouldCommit = commit && !sameOrder(ids, nextIds);
-      for (const row of rows) {
-        row.element.style.transition = `transform ${LABEL_REORDER_ANIMATION_MS}ms ease`;
-      }
+      setLabelRowTransitions(rows, `transform ${LABEL_REORDER_ANIMATION_MS}ms ease`);
       if (commit) {
         applyVirtualLayout(latestClientY, { snapDraggedToSlot: true });
       } else {
         latestNextIds = ids;
-        const originalTopById = targetTopsForOrder(ids, rowById, firstTop);
-        for (const row of rows) {
-          const targetTop = originalTopById.get(row.id) ?? row.top;
-          const deltaY = targetTop - row.top;
-          row.element.style.transform = deltaY === 0 ? "" : `translateY(${deltaY}px)`;
-        }
+        snapRowsToOrder(rows, ids, rowById, firstTop);
       }
 
       window.setTimeout(() => {
-        const visualTopById = new Map(rows.map((row) => [row.id, row.element.getBoundingClientRect().top]));
-        flushSync(() => {
+        keepVisualPositionsAfterCommit(rows, () => {
           setDraggingLabelId(null);
           if (shouldCommit) {
             onReorderLabel(labelId, nextIds.indexOf(labelId));
           }
-        });
-        for (const row of rows) {
-          row.element.style.transition = "none";
-          row.element.style.transform = "";
-          row.element.style.zIndex = "";
-        }
-        for (const row of rows) {
-          const visualTop = visualTopById.get(row.id);
-          if (visualTop === undefined) {
-            continue;
-          }
-          const naturalTop = row.element.getBoundingClientRect().top;
-          const deltaY = visualTop - naturalTop;
-          row.element.style.transform = deltaY === 0 ? "" : `translateY(${deltaY}px)`;
-        }
-        window.requestAnimationFrame(() => {
-          clearLabelRowStyles(rows);
         });
       }, LABEL_REORDER_ANIMATION_MS);
     }
@@ -401,9 +429,7 @@ export function SettingsView({
     setDraggingLabelId(labelId);
     for (const row of rows) {
       row.element.style.transition = row.id === labelId ? "none" : "transform 120ms ease";
-      if (row.id === labelId) {
-        row.element.style.zIndex = "2";
-      }
+      row.element.style.zIndex = row.id === labelId ? "2" : "";
     }
     handle.addEventListener("pointermove", onPointerMove);
     handle.addEventListener("pointerup", onPointerUp);

--- a/frontend/src/features/project-shell/SettingsView.tsx
+++ b/frontend/src/features/project-shell/SettingsView.tsx
@@ -549,6 +549,7 @@ export function SettingsView({
                     selected={label.id === selectedLabelId}
                     onClick={() => onSelectLabel(label.id)}
                     sx={{
+                      pl: 0,
                       transition: "background-color 120ms ease, box-shadow 120ms ease, transform 160ms ease",
                       ...(draggingLabelId === label.id
                         ? {
@@ -571,8 +572,8 @@ export function SettingsView({
                       }}
                       sx={{
                         alignSelf: "stretch",
-                        width: 32,
-                        minWidth: 32,
+                        width: 42,
+                        minWidth: 42,
                         mr: 1,
                         p: 0,
                         border: 0,

--- a/frontend/src/features/project-shell/SettingsView.tsx
+++ b/frontend/src/features/project-shell/SettingsView.tsx
@@ -31,6 +31,58 @@ import { getImportYourDataGuideUrl } from "../../externalLinks";
 import { useI18n } from "../../i18n/useI18n";
 import { getProjectGuideline } from "../../utils";
 
+type LabelRowElement = {
+  id: string;
+  element: HTMLDivElement;
+};
+
+function sameOrder(left: string[], right: string[]) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function labelRowsFromRefs(bundle: ProjectBundle, refs: Map<string, HTMLDivElement>) {
+  return bundle.labels
+    .map((label) => ({
+      id: label.id,
+      element: refs.get(label.id),
+    }))
+    .filter((item): item is LabelRowElement => Boolean(item.element));
+}
+
+function clearLabelRowStyles(rows: LabelRowElement[]) {
+  for (const row of rows) {
+    row.element.style.transition = "";
+    row.element.style.transform = "";
+    row.element.style.zIndex = "";
+  }
+}
+
+function applyReleaseAnimation(nextIds: string[], visualTopById: Map<string, number>, refs: Map<string, HTMLDivElement>) {
+  const rowsAfterCommit = nextIds
+    .map((id) => ({
+      id,
+      element: refs.get(id),
+    }))
+    .filter((item): item is LabelRowElement => Boolean(item.element));
+
+  for (const row of rowsAfterCommit) {
+    const visualTop = visualTopById.get(row.id);
+    if (visualTop === undefined) {
+      continue;
+    }
+    const deltaY = visualTop - row.element.getBoundingClientRect().top;
+    row.element.style.transition = "none";
+    row.element.style.transform = deltaY === 0 ? "" : `translateY(${deltaY}px)`;
+  }
+
+  window.requestAnimationFrame(() => {
+    for (const row of rowsAfterCommit) {
+      row.element.style.transition = "transform 160ms ease";
+      row.element.style.transform = "";
+    }
+  });
+}
+
 export function SettingsView({
   bundle,
   selectedLabelId,
@@ -115,20 +167,11 @@ export function SettingsView({
     labelRowRefs.current.delete(labelId);
   }
 
-  function sameOrder(left: string[], right: string[]) {
-    return left.length === right.length && left.every((value, index) => value === right[index]);
-  }
-
   function startLabelDrag(event: React.PointerEvent<HTMLButtonElement>, labelId: string) {
     if (event.pointerType === "mouse" && event.button !== 0) {
       return;
     }
-    const rows = bundle.labels
-      .map((label) => ({
-        id: label.id,
-        element: labelRowRefs.current.get(label.id),
-      }))
-      .filter((item): item is { id: string; element: HTMLDivElement } => Boolean(item.element));
+    const rows = labelRowsFromRefs(bundle, labelRowRefs.current);
     const ids = rows.map((item) => item.id);
     const from = ids.indexOf(labelId);
     const dragged = rows.find((item) => item.id === labelId);
@@ -185,6 +228,13 @@ export function SettingsView({
       }
     }
 
+    function flushScheduledTransforms() {
+      if (frameId) {
+        window.cancelAnimationFrame(frameId);
+      }
+      applyTransforms();
+    }
+
     function scheduleTransform(clientY: number) {
       latestClientY = clientY;
       if (!frameId) {
@@ -200,11 +250,7 @@ export function SettingsView({
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
       if (clearTransforms) {
-        for (const item of rows) {
-          item.element.style.transition = "";
-          item.element.style.transform = "";
-          item.element.style.zIndex = "";
-        }
+        clearLabelRowStyles(rows);
       }
       handle.removeEventListener("pointermove", onPointerMove);
       handle.removeEventListener("pointerup", onPointerUp);
@@ -219,43 +265,17 @@ export function SettingsView({
     function commitWithReleaseAnimation(nextIds: string[]) {
       const visualTopById = new Map(rows.map((item) => [item.id, item.element.getBoundingClientRect().top]));
       cleanup({ clearTransforms: false });
-      for (const item of rows) {
-        item.element.style.transition = "none";
-        item.element.style.transform = "";
-        item.element.style.zIndex = "";
-      }
+      clearLabelRowStyles(rows);
 
       flushSync(() => {
         onReorderLabel(labelId, nextIds.indexOf(labelId));
       });
 
-      const elementsAfterCommit = nextIds
-        .map((id) => ({
-          id,
-          element: labelRowRefs.current.get(id),
-        }))
-        .filter((item): item is { id: string; element: HTMLDivElement } => Boolean(item.element));
-
-      for (const item of elementsAfterCommit) {
-        const visualTop = visualTopById.get(item.id);
-        if (visualTop === undefined) {
-          continue;
-        }
-        const deltaY = visualTop - item.element.getBoundingClientRect().top;
-        item.element.style.transition = "none";
-        item.element.style.transform = deltaY === 0 ? "" : `translateY(${deltaY}px)`;
-      }
-
-      window.requestAnimationFrame(() => {
-        for (const item of elementsAfterCommit) {
-          item.element.style.transition = "transform 160ms ease";
-          item.element.style.transform = "";
-        }
-      });
+      applyReleaseAnimation(nextIds, visualTopById, labelRowRefs.current);
     }
 
     function finish(commit: boolean) {
-      insertIndex = computeInsertIndex(latestClientY);
+      flushScheduledTransforms();
       const nextIds = orderedIdsForInsert();
       if (commit && !sameOrder(ids, nextIds)) {
         commitWithReleaseAnimation(nextIds);

--- a/frontend/src/features/project-shell/SettingsView.tsx
+++ b/frontend/src/features/project-shell/SettingsView.tsx
@@ -16,8 +16,11 @@ import {
   Typography,
   alpha,
 } from "@mui/material";
+import { useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import AddRoundedIcon from "@mui/icons-material/AddRounded";
 import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
+import MenuRoundedIcon from "@mui/icons-material/MenuRounded";
 import DownloadRoundedIcon from "@mui/icons-material/DownloadRounded";
 import PaletteRoundedIcon from "@mui/icons-material/PaletteRounded";
 import SaveRoundedIcon from "@mui/icons-material/SaveRounded";
@@ -53,6 +56,7 @@ export function SettingsView({
   onSubmitLabelDraft,
   onResetLabelDraft,
   onSelectLabel,
+  onReorderLabel,
   onDeleteLabel,
   onImportFileChange,
   onImport,
@@ -87,6 +91,7 @@ export function SettingsView({
   onSubmitLabelDraft: () => void;
   onResetLabelDraft: () => void;
   onSelectLabel: (labelId: string) => void;
+  onReorderLabel: (labelId: string, targetIndex: number) => void;
   onDeleteLabel: (labelId: string) => void;
   onImportFileChange: (file: File | null) => void;
   onImport: () => void;
@@ -99,6 +104,203 @@ export function SettingsView({
 }) {
   const { locale, t } = useI18n();
   const guideUrl = getImportYourDataGuideUrl(locale);
+  const [draggingLabelId, setDraggingLabelId] = useState<string | null>(null);
+  const labelRowRefs = useRef(new Map<string, HTMLDivElement>());
+
+  function registerLabelRow(labelId: string, element: HTMLDivElement | null) {
+    if (element) {
+      labelRowRefs.current.set(labelId, element);
+      return;
+    }
+    labelRowRefs.current.delete(labelId);
+  }
+
+  function sameOrder(left: string[], right: string[]) {
+    return left.length === right.length && left.every((value, index) => value === right[index]);
+  }
+
+  function startLabelDrag(event: React.PointerEvent<HTMLButtonElement>, labelId: string) {
+    if (event.pointerType === "mouse" && event.button !== 0) {
+      return;
+    }
+    const rows = bundle.labels
+      .map((label) => ({
+        id: label.id,
+        element: labelRowRefs.current.get(label.id),
+      }))
+      .filter((item): item is { id: string; element: HTMLDivElement } => Boolean(item.element));
+    const ids = rows.map((item) => item.id);
+    const from = ids.indexOf(labelId);
+    const dragged = rows.find((item) => item.id === labelId);
+    if (from < 0 || !dragged) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.currentTarget.setPointerCapture) {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    }
+
+    const handle = event.currentTarget;
+    const rectById = new Map(rows.map((item) => [item.id, item.element.getBoundingClientRect()]));
+    const draggedRect = rectById.get(labelId);
+    const rowHeight = draggedRect?.height || dragged.element.getBoundingClientRect().height || 1;
+    const remainingIds = ids.filter((id) => id !== labelId);
+    let insertIndex = from;
+    let latestClientY = event.clientY;
+    let frameId = 0;
+
+    function computeInsertIndex(clientY: number) {
+      for (let index = 0; index < remainingIds.length; index += 1) {
+        const rect = rectById.get(remainingIds[index]);
+        if (rect && clientY < rect.top + rect.height / 2) {
+          return index;
+        }
+      }
+      return remainingIds.length;
+    }
+
+    function orderedIdsForInsert() {
+      const nextIds = [...remainingIds];
+      nextIds.splice(insertIndex, 0, labelId);
+      return nextIds;
+    }
+
+    function applyTransforms() {
+      frameId = 0;
+      insertIndex = computeInsertIndex(latestClientY);
+      const nextIds = orderedIdsForInsert();
+      const nextIndexById = new Map(nextIds.map((id, index) => [id, index]));
+
+      for (const item of rows) {
+        if (item.id === labelId) {
+          item.element.style.transform = `translateY(${latestClientY - event.clientY}px)`;
+          continue;
+        }
+        const originalIndex = ids.indexOf(item.id);
+        const nextIndex = nextIndexById.get(item.id);
+        const deltaY = nextIndex === undefined ? 0 : (nextIndex - originalIndex) * rowHeight;
+        item.element.style.transform = deltaY === 0 ? "" : `translateY(${deltaY}px)`;
+      }
+    }
+
+    function scheduleTransform(clientY: number) {
+      latestClientY = clientY;
+      if (!frameId) {
+        frameId = window.requestAnimationFrame(applyTransforms);
+      }
+    }
+
+    function cleanup({ clearTransforms }: { clearTransforms: boolean }) {
+      if (frameId) {
+        window.cancelAnimationFrame(frameId);
+        frameId = 0;
+      }
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      if (clearTransforms) {
+        for (const item of rows) {
+          item.element.style.transition = "";
+          item.element.style.transform = "";
+          item.element.style.zIndex = "";
+        }
+      }
+      handle.removeEventListener("pointermove", onPointerMove);
+      handle.removeEventListener("pointerup", onPointerUp);
+      handle.removeEventListener("pointercancel", onPointerCancel);
+      document.removeEventListener("keydown", onKeyDown);
+      if (handle.hasPointerCapture?.(event.pointerId)) {
+        handle.releasePointerCapture(event.pointerId);
+      }
+      setDraggingLabelId(null);
+    }
+
+    function commitWithReleaseAnimation(nextIds: string[]) {
+      const visualTopById = new Map(rows.map((item) => [item.id, item.element.getBoundingClientRect().top]));
+      cleanup({ clearTransforms: false });
+      for (const item of rows) {
+        item.element.style.transition = "none";
+        item.element.style.transform = "";
+        item.element.style.zIndex = "";
+      }
+
+      flushSync(() => {
+        onReorderLabel(labelId, nextIds.indexOf(labelId));
+      });
+
+      const elementsAfterCommit = nextIds
+        .map((id) => ({
+          id,
+          element: labelRowRefs.current.get(id),
+        }))
+        .filter((item): item is { id: string; element: HTMLDivElement } => Boolean(item.element));
+
+      for (const item of elementsAfterCommit) {
+        const visualTop = visualTopById.get(item.id);
+        if (visualTop === undefined) {
+          continue;
+        }
+        const deltaY = visualTop - item.element.getBoundingClientRect().top;
+        item.element.style.transition = "none";
+        item.element.style.transform = deltaY === 0 ? "" : `translateY(${deltaY}px)`;
+      }
+
+      window.requestAnimationFrame(() => {
+        for (const item of elementsAfterCommit) {
+          item.element.style.transition = "transform 160ms ease";
+          item.element.style.transform = "";
+        }
+      });
+    }
+
+    function finish(commit: boolean) {
+      insertIndex = computeInsertIndex(latestClientY);
+      const nextIds = orderedIdsForInsert();
+      if (commit && !sameOrder(ids, nextIds)) {
+        commitWithReleaseAnimation(nextIds);
+        return;
+      }
+      cleanup({ clearTransforms: true });
+    }
+
+    function onPointerMove(moveEvent: PointerEvent) {
+      moveEvent.preventDefault();
+      scheduleTransform(moveEvent.clientY);
+    }
+
+    function onPointerUp(upEvent: PointerEvent) {
+      upEvent.preventDefault();
+      finish(true);
+    }
+
+    function onPointerCancel(cancelEvent: PointerEvent) {
+      cancelEvent.preventDefault();
+      finish(false);
+    }
+
+    function onKeyDown(keyEvent: KeyboardEvent) {
+      if (keyEvent.key === "Escape") {
+        keyEvent.preventDefault();
+        finish(false);
+      }
+    }
+
+    document.body.style.cursor = "grabbing";
+    document.body.style.userSelect = "none";
+    setDraggingLabelId(labelId);
+    for (const item of rows) {
+      item.element.style.transition = item.id === labelId ? "none" : "transform 120ms ease";
+      if (item.id === labelId) {
+        item.element.style.zIndex = "2";
+      }
+    }
+    handle.addEventListener("pointermove", onPointerMove);
+    handle.addEventListener("pointerup", onPointerUp);
+    handle.addEventListener("pointercancel", onPointerCancel);
+    document.addEventListener("keydown", onKeyDown);
+    scheduleTransform(event.clientY);
+  }
 
   return (
     <Box sx={{ display: "grid", gap: 2, height: "100%", minHeight: 0, gridTemplateRows: "minmax(0,1fr) auto" }}>
@@ -227,9 +429,58 @@ export function SettingsView({
                 {bundle.labels.map((label) => (
                   <ListItemButton
                     key={label.id}
+                    ref={(element) => registerLabelRow(label.id, element)}
                     selected={label.id === selectedLabelId}
                     onClick={() => onSelectLabel(label.id)}
+                    sx={{
+                      transition: "background-color 120ms ease, box-shadow 120ms ease, transform 160ms ease",
+                      ...(draggingLabelId === label.id
+                        ? {
+                            bgcolor: alpha(label.color, 0.12),
+                            boxShadow: `inset 3px 0 0 ${label.color}`,
+                            zIndex: 1,
+                          }
+                        : {}),
+                    }}
                   >
+                    <Box
+                      component="button"
+                      type="button"
+                      aria-label={t("projectShell.settings.dragLabel", { name: label.name })}
+                      onPointerDown={(event) => {
+                        startLabelDrag(event, label.id);
+                      }}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                      }}
+                      sx={{
+                        alignSelf: "stretch",
+                        width: 32,
+                        minWidth: 32,
+                        mr: 1,
+                        p: 0,
+                        border: 0,
+                        borderRight: "1px solid",
+                        borderColor: alpha("#16324f", 0.1),
+                        bgcolor: "transparent",
+                        color: "text.secondary",
+                        cursor: draggingLabelId === label.id ? "grabbing" : "grab",
+                        touchAction: "none",
+                        display: "grid",
+                        placeItems: "center",
+                        "&:hover": {
+                          color: "primary.main",
+                          bgcolor: alpha("#1a73e8", 0.06),
+                        },
+                        "&:focus-visible": {
+                          outline: "2px solid",
+                          outlineColor: "primary.main",
+                          outlineOffset: -2,
+                        },
+                      }}
+                    >
+                      <MenuRoundedIcon fontSize="small" />
+                    </Box>
                     <ListItemText
                       primary={
                         <Stack direction="row" spacing={1} alignItems="center">

--- a/frontend/src/features/project-shell/SettingsView.tsx
+++ b/frontend/src/features/project-shell/SettingsView.tsx
@@ -16,7 +16,7 @@ import {
   Typography,
   alpha,
 } from "@mui/material";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import AddRoundedIcon from "@mui/icons-material/AddRounded";
 import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
@@ -271,6 +271,19 @@ export function SettingsView({
   const guideUrl = getImportYourDataGuideUrl(locale);
   const [draggingLabelId, setDraggingLabelId] = useState<string | null>(null);
   const labelRowRefs = useRef(new Map<string, HTMLDivElement>());
+  const activeLabelDragCleanupRef = useRef<(() => void) | null>(null);
+  const labelReorderTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      activeLabelDragCleanupRef.current?.();
+      activeLabelDragCleanupRef.current = null;
+      if (labelReorderTimeoutRef.current !== null) {
+        window.clearTimeout(labelReorderTimeoutRef.current);
+        labelReorderTimeoutRef.current = null;
+      }
+    };
+  }, []);
 
   function registerLabelRow(labelId: string, element: HTMLDivElement | null) {
     if (element) {
@@ -308,6 +321,8 @@ export function SettingsView({
     let frameId = 0;
     let finished = false;
 
+    activeLabelDragCleanupRef.current?.();
+
     function applyVirtualLayout(clientY: number, options: { snapDraggedToSlot: boolean }) {
       frameId = 0;
       const draggedTop = clamp(clientY - pointerOffsetY, firstTop, maxDraggedTop);
@@ -344,9 +359,6 @@ export function SettingsView({
     }
 
     function removeDragListeners() {
-      handle.removeEventListener("pointermove", onPointerMove);
-      handle.removeEventListener("pointerup", onPointerUp);
-      handle.removeEventListener("pointercancel", onPointerCancel);
       handle.removeEventListener("lostpointercapture", onLostPointerCapture);
       document.removeEventListener("pointermove", onPointerMove);
       document.removeEventListener("pointerup", onPointerUp);
@@ -357,6 +369,21 @@ export function SettingsView({
       if (handle.hasPointerCapture?.(event.pointerId)) {
         handle.releasePointerCapture(event.pointerId);
       }
+    }
+
+    function cleanupActiveDrag() {
+      if (frameId) {
+        window.cancelAnimationFrame(frameId);
+        frameId = 0;
+      }
+      if (labelReorderTimeoutRef.current !== null) {
+        window.clearTimeout(labelReorderTimeoutRef.current);
+        labelReorderTimeoutRef.current = null;
+      }
+      removeDragListeners();
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      clearLabelRowStyles(rows);
     }
 
     function finish(commit: boolean) {
@@ -379,7 +406,12 @@ export function SettingsView({
         snapRowsToOrder(rows, ids, rowById, firstTop);
       }
 
-      window.setTimeout(() => {
+      if (labelReorderTimeoutRef.current !== null) {
+        window.clearTimeout(labelReorderTimeoutRef.current);
+      }
+      labelReorderTimeoutRef.current = window.setTimeout(() => {
+        labelReorderTimeoutRef.current = null;
+        activeLabelDragCleanupRef.current = null;
         keepVisualPositionsAfterCommit(rows, () => {
           setDraggingLabelId(null);
           if (shouldCommit) {
@@ -426,14 +458,12 @@ export function SettingsView({
 
     document.body.style.cursor = "grabbing";
     document.body.style.userSelect = "none";
+    activeLabelDragCleanupRef.current = cleanupActiveDrag;
     setDraggingLabelId(labelId);
     for (const row of rows) {
       row.element.style.transition = row.id === labelId ? "none" : "transform 120ms ease";
       row.element.style.zIndex = row.id === labelId ? "2" : "";
     }
-    handle.addEventListener("pointermove", onPointerMove);
-    handle.addEventListener("pointerup", onPointerUp);
-    handle.addEventListener("pointercancel", onPointerCancel);
     handle.addEventListener("lostpointercapture", onLostPointerCapture);
     document.addEventListener("pointermove", onPointerMove);
     document.addEventListener("pointerup", onPointerUp);

--- a/frontend/src/features/project-shell/SettingsView.tsx
+++ b/frontend/src/features/project-shell/SettingsView.tsx
@@ -36,6 +36,13 @@ type LabelRowElement = {
   element: HTMLDivElement;
 };
 
+type LabelDragRow = LabelRowElement & {
+  top: number;
+  height: number;
+};
+
+const LABEL_REORDER_ANIMATION_MS = 140;
+
 function sameOrder(left: string[], right: string[]) {
   return left.length === right.length && left.every((value, index) => value === right[index]);
 }
@@ -57,30 +64,73 @@ function clearLabelRowStyles(rows: LabelRowElement[]) {
   }
 }
 
-function applyReleaseAnimation(nextIds: string[], visualTopById: Map<string, number>, refs: Map<string, HTMLDivElement>) {
-  const rowsAfterCommit = nextIds
-    .map((id) => ({
-      id,
-      element: refs.get(id),
-    }))
-    .filter((item): item is LabelRowElement => Boolean(item.element));
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
 
-  for (const row of rowsAfterCommit) {
-    const visualTop = visualTopById.get(row.id);
-    if (visualTop === undefined) {
+function targetTopsForOrder(ids: string[], rowById: Map<string, LabelDragRow>, startTop: number) {
+  const targetTopById = new Map<string, number>();
+  let nextTop = startTop;
+  for (const id of ids) {
+    const row = rowById.get(id);
+    if (!row) {
       continue;
     }
-    const deltaY = visualTop - row.element.getBoundingClientRect().top;
-    row.element.style.transition = "none";
-    row.element.style.transform = deltaY === 0 ? "" : `translateY(${deltaY}px)`;
+    targetTopById.set(id, nextTop);
+    nextTop += row.height;
+  }
+  return targetTopById;
+}
+
+function orderIdsByDragBoundaries(
+  currentIds: string[],
+  draggedId: string,
+  draggedTop: number,
+  draggedHeight: number,
+  rowById: Map<string, LabelDragRow>,
+  startTop: number,
+) {
+  const currentTopById = targetTopsForOrder(currentIds, rowById, startTop);
+  const draggedIndex = currentIds.indexOf(draggedId);
+  if (draggedIndex < 0) {
+    return currentIds;
+  }
+  const currentIndexById = new Map(currentIds.map((id, index) => [id, index]));
+  const upperProbeY = draggedTop;
+  const lowerProbeY = draggedTop + draggedHeight;
+  const beforeDragged: string[] = [];
+  const afterDragged: string[] = [];
+
+  for (const id of currentIds) {
+    if (id === draggedId) {
+      continue;
+    }
+    const row = rowById.get(id);
+    const currentTop = currentTopById.get(id);
+    if (!row || currentTop === undefined) {
+      continue;
+    }
+    const centerY = currentTop + row.height / 2;
+    const currentIndex = currentIndexById.get(id);
+    const isCurrentlyBeforeDragged = currentIndex !== undefined && currentIndex < draggedIndex;
+
+    if (isCurrentlyBeforeDragged) {
+      if (centerY > upperProbeY) {
+        afterDragged.push(id);
+      } else {
+        beforeDragged.push(id);
+      }
+      continue;
+    }
+
+    if (centerY < lowerProbeY) {
+      beforeDragged.push(id);
+    } else {
+      afterDragged.push(id);
+    }
   }
 
-  window.requestAnimationFrame(() => {
-    for (const row of rowsAfterCommit) {
-      row.element.style.transition = "transform 160ms ease";
-      row.element.style.transform = "";
-    }
-  });
+  return [...beforeDragged, draggedId, ...afterDragged];
 }
 
 export function SettingsView({
@@ -171,13 +221,21 @@ export function SettingsView({
     if (event.pointerType === "mouse" && event.button !== 0) {
       return;
     }
-    const rows = labelRowsFromRefs(bundle, labelRowRefs.current);
-    const ids = rows.map((item) => item.id);
+    const rows = labelRowsFromRefs(bundle, labelRowRefs.current).map((row) => {
+      const rect = row.element.getBoundingClientRect();
+      return {
+        ...row,
+        top: rect.top,
+        height: rect.height || 1,
+      };
+    });
+    const ids = rows.map((row) => row.id);
     const from = ids.indexOf(labelId);
-    const dragged = rows.find((item) => item.id === labelId);
+    const dragged = rows.find((row) => row.id === labelId);
     if (from < 0 || !dragged) {
       return;
     }
+    const draggedRow = dragged;
 
     event.preventDefault();
     event.stopPropagation();
@@ -186,102 +244,121 @@ export function SettingsView({
     }
 
     const handle = event.currentTarget;
-    const rectById = new Map(rows.map((item) => [item.id, item.element.getBoundingClientRect()]));
-    const draggedRect = rectById.get(labelId);
-    const rowHeight = draggedRect?.height || dragged.element.getBoundingClientRect().height || 1;
-    const remainingIds = ids.filter((id) => id !== labelId);
-    let insertIndex = from;
+    const rowById = new Map(rows.map((row) => [row.id, row]));
+    const firstTop = Math.min(...rows.map((row) => row.top));
+    const lastBottom = Math.max(...rows.map((row) => row.top + row.height));
+    const maxDraggedTop = Math.max(firstTop, lastBottom - draggedRow.height);
+    const pointerOffsetY = event.clientY - draggedRow.top;
+    let latestNextIds = ids;
     let latestClientY = event.clientY;
     let frameId = 0;
+    let finished = false;
 
-    function computeInsertIndex(clientY: number) {
-      for (let index = 0; index < remainingIds.length; index += 1) {
-        const rect = rectById.get(remainingIds[index]);
-        if (rect && clientY < rect.top + rect.height / 2) {
-          return index;
-        }
-      }
-      return remainingIds.length;
-    }
-
-    function orderedIdsForInsert() {
-      const nextIds = [...remainingIds];
-      nextIds.splice(insertIndex, 0, labelId);
-      return nextIds;
-    }
-
-    function applyTransforms() {
+    function applyVirtualLayout(clientY: number, options: { snapDraggedToSlot: boolean }) {
       frameId = 0;
-      insertIndex = computeInsertIndex(latestClientY);
-      const nextIds = orderedIdsForInsert();
-      const nextIndexById = new Map(nextIds.map((id, index) => [id, index]));
+      const draggedTop = clamp(clientY - pointerOffsetY, firstTop, maxDraggedTop);
+      const nextIds = orderIdsByDragBoundaries(latestNextIds, labelId, draggedTop, draggedRow.height, rowById, firstTop);
+      const targetTopById = targetTopsForOrder(nextIds, rowById, firstTop);
+      latestNextIds = nextIds;
 
-      for (const item of rows) {
-        if (item.id === labelId) {
-          item.element.style.transform = `translateY(${latestClientY - event.clientY}px)`;
+      for (const row of rows) {
+        const targetTop = targetTopById.get(row.id);
+        if (targetTop === undefined) {
           continue;
         }
-        const originalIndex = ids.indexOf(item.id);
-        const nextIndex = nextIndexById.get(item.id);
-        const deltaY = nextIndex === undefined ? 0 : (nextIndex - originalIndex) * rowHeight;
-        item.element.style.transform = deltaY === 0 ? "" : `translateY(${deltaY}px)`;
+        const visualTop =
+          row.id === labelId && !options.snapDraggedToSlot
+            ? draggedTop
+            : targetTop;
+        const deltaY = visualTop - row.top;
+        row.element.style.transform = deltaY === 0 ? "" : `translateY(${deltaY}px)`;
       }
     }
 
     function flushScheduledTransforms() {
       if (frameId) {
         window.cancelAnimationFrame(frameId);
+        frameId = 0;
       }
-      applyTransforms();
+      applyVirtualLayout(latestClientY, { snapDraggedToSlot: false });
     }
 
     function scheduleTransform(clientY: number) {
       latestClientY = clientY;
       if (!frameId) {
-        frameId = window.requestAnimationFrame(applyTransforms);
+        frameId = window.requestAnimationFrame(() => applyVirtualLayout(latestClientY, { snapDraggedToSlot: false }));
       }
     }
 
-    function cleanup({ clearTransforms }: { clearTransforms: boolean }) {
-      if (frameId) {
-        window.cancelAnimationFrame(frameId);
-        frameId = 0;
-      }
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-      if (clearTransforms) {
-        clearLabelRowStyles(rows);
-      }
+    function removeDragListeners() {
       handle.removeEventListener("pointermove", onPointerMove);
       handle.removeEventListener("pointerup", onPointerUp);
       handle.removeEventListener("pointercancel", onPointerCancel);
+      handle.removeEventListener("lostpointercapture", onLostPointerCapture);
+      document.removeEventListener("pointermove", onPointerMove);
+      document.removeEventListener("pointerup", onPointerUp);
+      document.removeEventListener("pointercancel", onPointerCancel);
+      document.removeEventListener("mouseup", onMouseUp);
       document.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("blur", onWindowBlur);
       if (handle.hasPointerCapture?.(event.pointerId)) {
         handle.releasePointerCapture(event.pointerId);
       }
-      setDraggingLabelId(null);
-    }
-
-    function commitWithReleaseAnimation(nextIds: string[]) {
-      const visualTopById = new Map(rows.map((item) => [item.id, item.element.getBoundingClientRect().top]));
-      cleanup({ clearTransforms: false });
-      clearLabelRowStyles(rows);
-
-      flushSync(() => {
-        onReorderLabel(labelId, nextIds.indexOf(labelId));
-      });
-
-      applyReleaseAnimation(nextIds, visualTopById, labelRowRefs.current);
     }
 
     function finish(commit: boolean) {
-      flushScheduledTransforms();
-      const nextIds = orderedIdsForInsert();
-      if (commit && !sameOrder(ids, nextIds)) {
-        commitWithReleaseAnimation(nextIds);
+      if (finished) {
         return;
       }
-      cleanup({ clearTransforms: true });
+      finished = true;
+      flushScheduledTransforms();
+      removeDragListeners();
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+
+      const nextIds = commit ? latestNextIds : ids;
+      const shouldCommit = commit && !sameOrder(ids, nextIds);
+      for (const row of rows) {
+        row.element.style.transition = `transform ${LABEL_REORDER_ANIMATION_MS}ms ease`;
+      }
+      if (commit) {
+        applyVirtualLayout(latestClientY, { snapDraggedToSlot: true });
+      } else {
+        latestNextIds = ids;
+        const originalTopById = targetTopsForOrder(ids, rowById, firstTop);
+        for (const row of rows) {
+          const targetTop = originalTopById.get(row.id) ?? row.top;
+          const deltaY = targetTop - row.top;
+          row.element.style.transform = deltaY === 0 ? "" : `translateY(${deltaY}px)`;
+        }
+      }
+
+      window.setTimeout(() => {
+        const visualTopById = new Map(rows.map((row) => [row.id, row.element.getBoundingClientRect().top]));
+        flushSync(() => {
+          setDraggingLabelId(null);
+          if (shouldCommit) {
+            onReorderLabel(labelId, nextIds.indexOf(labelId));
+          }
+        });
+        for (const row of rows) {
+          row.element.style.transition = "none";
+          row.element.style.transform = "";
+          row.element.style.zIndex = "";
+        }
+        for (const row of rows) {
+          const visualTop = visualTopById.get(row.id);
+          if (visualTop === undefined) {
+            continue;
+          }
+          const naturalTop = row.element.getBoundingClientRect().top;
+          const deltaY = visualTop - naturalTop;
+          row.element.style.transform = deltaY === 0 ? "" : `translateY(${deltaY}px)`;
+        }
+        window.requestAnimationFrame(() => {
+          clearLabelRowStyles(rows);
+        });
+      }, LABEL_REORDER_ANIMATION_MS);
     }
 
     function onPointerMove(moveEvent: PointerEvent) {
@@ -294,8 +371,21 @@ export function SettingsView({
       finish(true);
     }
 
+    function onMouseUp(mouseEvent: MouseEvent) {
+      mouseEvent.preventDefault();
+      finish(true);
+    }
+
     function onPointerCancel(cancelEvent: PointerEvent) {
       cancelEvent.preventDefault();
+      finish(false);
+    }
+
+    function onLostPointerCapture() {
+      finish(true);
+    }
+
+    function onWindowBlur() {
       finish(false);
     }
 
@@ -309,16 +399,22 @@ export function SettingsView({
     document.body.style.cursor = "grabbing";
     document.body.style.userSelect = "none";
     setDraggingLabelId(labelId);
-    for (const item of rows) {
-      item.element.style.transition = item.id === labelId ? "none" : "transform 120ms ease";
-      if (item.id === labelId) {
-        item.element.style.zIndex = "2";
+    for (const row of rows) {
+      row.element.style.transition = row.id === labelId ? "none" : "transform 120ms ease";
+      if (row.id === labelId) {
+        row.element.style.zIndex = "2";
       }
     }
     handle.addEventListener("pointermove", onPointerMove);
     handle.addEventListener("pointerup", onPointerUp);
     handle.addEventListener("pointercancel", onPointerCancel);
+    handle.addEventListener("lostpointercapture", onLostPointerCapture);
+    document.addEventListener("pointermove", onPointerMove);
+    document.addEventListener("pointerup", onPointerUp);
+    document.addEventListener("pointercancel", onPointerCancel);
+    document.addEventListener("mouseup", onMouseUp);
     document.addEventListener("keydown", onKeyDown);
+    window.addEventListener("blur", onWindowBlur);
     scheduleTransform(event.clientY);
   }
 

--- a/frontend/src/i18n/messages/en.ts
+++ b/frontend/src/i18n/messages/en.ts
@@ -114,6 +114,7 @@ export const enMessages: Messages = {
       updateLabel: "Update label",
       addLabel: "Add label",
       clear: "Clear",
+      dragLabel: "Drag to reorder {{name}}",
       deleteLabel: "Delete {{name}}",
       importExportTitle: "Import / Export",
       importTitle: "Append import into current project",

--- a/frontend/src/i18n/messages/ja.ts
+++ b/frontend/src/i18n/messages/ja.ts
@@ -112,6 +112,7 @@ export const jaMessages = {
       updateLabel: "Update label",
       addLabel: "Add label",
       clear: "Clear",
+      dragLabel: "{{name}} の表示順をドラッグで変更",
       deleteLabel: "{{name}} を削除",
       importExportTitle: "Import / Export",
       importTitle: "現在 project への追記 import",

--- a/frontend/src/i18n/messages/zh-CN.ts
+++ b/frontend/src/i18n/messages/zh-CN.ts
@@ -113,6 +113,7 @@ export const zhCnMessages: Messages = {
       updateLabel: "更新标签",
       addLabel: "添加标签",
       clear: "清空",
+      dragLabel: "拖拽调整 {{name}} 的顺序",
       deleteLabel: "删除 {{name}}",
       importExportTitle: "导入 / 导出",
       importTitle: "向当前项目追加导入",

--- a/frontend/src/test/projectShellSettings.test.tsx
+++ b/frontend/src/test/projectShellSettings.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ProjectShell } from "../App";
@@ -254,13 +254,13 @@ describe("ProjectShell settings label selection", () => {
     const nameInput = screen.getByLabelText("Name");
     await userEventSetup.click(getLabelRow("患者メタデータ"));
 
-    await userEventSetup.click(within(getLabelRow("病名")).getByRole("button"));
+    await userEventSetup.click(within(getLabelRow("病名")).getByRole("button", { name: "病名 を削除" }));
 
     expect(screen.queryByText("病名")).not.toBeInTheDocument();
     expect(nameInput).toHaveValue("患者メタデータ");
     expect(getLabelRow("患者メタデータ")).toHaveClass("Mui-selected");
 
-    await userEventSetup.click(within(getLabelRow("患者メタデータ")).getByRole("button"));
+    await userEventSetup.click(within(getLabelRow("患者メタデータ")).getByRole("button", { name: "患者メタデータ を削除" }));
 
     await waitFor(() => {
       expect(screen.queryByText("患者メタデータ")).not.toBeInTheDocument();
@@ -286,6 +286,71 @@ describe("ProjectShell settings label selection", () => {
     expect(screen.getAllByText("主訴")).toHaveLength(1);
     expect(screen.getByText("病名")).toBeInTheDocument();
     expect(getLabelRow("病名")).toHaveClass("Mui-selected");
+  });
+
+  it("reorders labels with the vertical drag handle and saves the reordered payload", async () => {
+    const userEventSetup = userEvent.setup();
+    const saveProjectLabelsSpy = vi.spyOn(api, "saveProjectLabels").mockResolvedValue({
+      labels: [baseLabels[1], baseLabels[0], baseLabels[2]],
+      revision: "labels-revision-2",
+    });
+    renderProjectSettings();
+
+    await screen.findByRole("heading", { name: "Project Settings" });
+
+    const firstRow = getLabelRow("主訴");
+    const secondRow = getLabelRow("病名");
+    const thirdRow = getLabelRow("患者メタデータ");
+    vi.spyOn(firstRow, "getBoundingClientRect").mockReturnValue({
+      top: 0,
+      bottom: 48,
+      left: 0,
+      right: 320,
+      width: 320,
+      height: 48,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    vi.spyOn(secondRow, "getBoundingClientRect").mockReturnValue({
+      top: 48,
+      bottom: 96,
+      left: 0,
+      right: 320,
+      width: 320,
+      height: 48,
+      x: 0,
+      y: 48,
+      toJSON: () => ({}),
+    });
+    vi.spyOn(thirdRow, "getBoundingClientRect").mockReturnValue({
+      top: 96,
+      bottom: 144,
+      left: 0,
+      right: 320,
+      width: 320,
+      height: 48,
+      x: 0,
+      y: 96,
+      toJSON: () => ({}),
+    });
+
+    const handle = screen.getByRole("button", { name: "病名 の表示順をドラッグで変更" });
+    fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientY: 72 });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientY: 10 });
+    fireEvent.pointerUp(handle, { pointerId: 1, clientY: 10 });
+
+    await userEventSetup.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(saveProjectLabelsSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(saveProjectLabelsSpy.mock.calls[0][1].map((label) => label.name)).toEqual([
+      "病名",
+      "主訴",
+      "患者メタデータ",
+    ]);
+    expect(saveProjectLabelsSpy.mock.calls[0][2]).toBe("labels-revision-1");
   });
 });
 

--- a/frontend/src/test/projectShellSettings.test.tsx
+++ b/frontend/src/test/projectShellSettings.test.tsx
@@ -91,6 +91,20 @@ function getLabelRow(name: string) {
   return row;
 }
 
+function mockLabelRowRect(name: string, top: number, height: number) {
+  vi.spyOn(getLabelRow(name), "getBoundingClientRect").mockReturnValue({
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 320,
+    width: 320,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  });
+}
+
 function renderProjectSettings(locale: "ja" | "en" | "zh-CN" = "ja") {
   vi.spyOn(api, "getProject").mockResolvedValue(project);
   vi.spyOn(api, "listLabels").mockResolvedValue({ labels: structuredClone(baseLabels), revision: "labels-revision-1" });
@@ -298,48 +312,18 @@ describe("ProjectShell settings label selection", () => {
 
     await screen.findByRole("heading", { name: "Project Settings" });
 
-    const firstRow = getLabelRow("主訴");
-    const secondRow = getLabelRow("病名");
-    const thirdRow = getLabelRow("患者メタデータ");
-    vi.spyOn(firstRow, "getBoundingClientRect").mockReturnValue({
-      top: 0,
-      bottom: 48,
-      left: 0,
-      right: 320,
-      width: 320,
-      height: 48,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    });
-    vi.spyOn(secondRow, "getBoundingClientRect").mockReturnValue({
-      top: 48,
-      bottom: 96,
-      left: 0,
-      right: 320,
-      width: 320,
-      height: 48,
-      x: 0,
-      y: 48,
-      toJSON: () => ({}),
-    });
-    vi.spyOn(thirdRow, "getBoundingClientRect").mockReturnValue({
-      top: 96,
-      bottom: 144,
-      left: 0,
-      right: 320,
-      width: 320,
-      height: 48,
-      x: 0,
-      y: 96,
-      toJSON: () => ({}),
-    });
+    mockLabelRowRect("主訴", 0, 48);
+    mockLabelRowRect("病名", 48, 48);
+    mockLabelRowRect("患者メタデータ", 96, 48);
 
     const handle = screen.getByRole("button", { name: "病名 の表示順をドラッグで変更" });
     fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientY: 72 });
-    fireEvent.pointerMove(handle, { pointerId: 1, clientY: 10 });
-    fireEvent.pointerUp(handle, { pointerId: 1, clientY: 10 });
+    fireEvent.pointerMove(document, { pointerId: 1, clientY: 10 });
+    fireEvent(handle, new Event("lostpointercapture"));
 
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save changes" })).not.toBeDisabled();
+    });
     await userEventSetup.click(screen.getByRole("button", { name: "Save changes" }));
 
     await waitFor(() => {
@@ -351,6 +335,40 @@ describe("ProjectShell settings label selection", () => {
       "患者メタデータ",
     ]);
     expect(saveProjectLabelsSpy.mock.calls[0][2]).toBe("labels-revision-1");
+  });
+
+  it("moves a tall label to the bottom when its lower boundary crosses following labels", async () => {
+    const userEventSetup = userEvent.setup();
+    const saveProjectLabelsSpy = vi.spyOn(api, "saveProjectLabels").mockResolvedValue({
+      labels: [baseLabels[0], baseLabels[2], baseLabels[1]],
+      revision: "labels-revision-2",
+    });
+    renderProjectSettings();
+
+    await screen.findByRole("heading", { name: "Project Settings" });
+
+    mockLabelRowRect("主訴", 0, 48);
+    mockLabelRowRect("病名", 48, 240);
+    mockLabelRowRect("患者メタデータ", 288, 48);
+
+    const handle = screen.getByRole("button", { name: "病名 の表示順をドラッグで変更" });
+    fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientY: 72 });
+    fireEvent.pointerMove(document, { pointerId: 1, clientY: 300 });
+    fireEvent(handle, new Event("lostpointercapture"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save changes" })).not.toBeDisabled();
+    });
+    await userEventSetup.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(saveProjectLabelsSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(saveProjectLabelsSpy.mock.calls[0][1].map((label) => label.name)).toEqual([
+      "主訴",
+      "患者メタデータ",
+      "病名",
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- `labels.display_order` を追加し、ラベル配列の順序を保存順として扱うようにした
- Project Settings にドラッグ可能なグラブハンドル付きの並び替え UI を追加した
- export/import、revision、legacy DB の backfill を含めてラベル順を一貫して保持するようにした
- 関連 API 仕様、DB スキーマ、Workspace 仕様、i18n を更新した

## Testing
- backend の関連テストを追加・更新し、ラベル順の保存、revision 更新、legacy DB の backfill、import/export の順序維持を検証した
- frontend の SettingsView の並び替え挙動をテスト追加し、手動でもドラッグ操作と保存後の反映を確認した