### PR TITLE
WorkspaceのDocument詳細cacheに上限を追加

### DIFF
--- a/docs/frontend/workspace-spec.md
+++ b/docs/frontend/workspace-spec.md
@@ -67,6 +67,7 @@
 - Label Selector は幅に応じて最大 3 行まで折り返し、3 行を超える場合は領域内で縦スクロール可能とする。
 - Label は単一選択とする（注目ラベルは1つ）。
 - 中央ペインは現在選択中 Document の本文と annotations を表示対象とし、左ペインの仮想化や古い行の破棄とは独立して保持する。
+- frontend が保持する Document 詳細（本文と annotations）は、現在選択中 Document、未保存変更中 Document、直近利用 Document の短期 cache に限定する。cache から破棄する場合は、対応する snapshot も同じ方針で破棄する。
 - 本文フォントサイズは `18px` とする。
 - Label Selector の表示色は各 Label の色定義に合わせる（マーカー色と統一）。
 - Layered 表示ルールは以下で確定する。

--- a/frontend/src/features/project-shell/projectShellConstants.ts
+++ b/frontend/src/features/project-shell/projectShellConstants.ts
@@ -1,7 +1,7 @@
 import type { Theme } from "@mui/material/styles";
 
 export const EXAMPLES_BATCH_SIZE = 8;
-export const DOCUMENT_DETAIL_CACHE_RECENT_SIZE = 5;
+export const DOCUMENT_DETAIL_CACHE_RECENT_SIZE = 20;
 export const DOCUMENT_PAGE_SIZE = 40;
 export const DOCUMENT_WINDOW_SIZE = 120;
 export const DEFAULT_LABEL_COLOR = "#1a73e8";

--- a/frontend/src/features/project-shell/projectShellConstants.ts
+++ b/frontend/src/features/project-shell/projectShellConstants.ts
@@ -1,6 +1,7 @@
 import type { Theme } from "@mui/material/styles";
 
 export const EXAMPLES_BATCH_SIZE = 8;
+export const DOCUMENT_DETAIL_CACHE_RECENT_SIZE = 5;
 export const DOCUMENT_PAGE_SIZE = 40;
 export const DOCUMENT_WINDOW_SIZE = 120;
 export const DEFAULT_LABEL_COLOR = "#1a73e8";

--- a/frontend/src/features/project-shell/useDocumentHistory.ts
+++ b/frontend/src/features/project-shell/useDocumentHistory.ts
@@ -31,13 +31,7 @@ export function useDocumentHistory({
   });
 
   useEffect(() => {
-    if (!currentDocument) {
-      if (historyState.documentId !== null) {
-        setHistoryState({ documentId: null, entries: [], index: -1 });
-      }
-      return;
-    }
-    if (historyState.documentId === currentDocument.id) {
+    if (!currentDocument || historyState.documentId === currentDocument.id) {
       return;
     }
     setHistoryState({

--- a/frontend/src/features/project-shell/useDocumentHistory.ts
+++ b/frontend/src/features/project-shell/useDocumentHistory.ts
@@ -31,7 +31,13 @@ export function useDocumentHistory({
   });
 
   useEffect(() => {
-    if (!currentDocument || historyState.documentId === currentDocument.id) {
+    if (!currentDocument) {
+      if (historyState.documentId !== null) {
+        setHistoryState({ documentId: null, entries: [], index: -1 });
+      }
+      return;
+    }
+    if (historyState.documentId === currentDocument.id) {
       return;
     }
     setHistoryState({

--- a/frontend/src/features/project-shell/useProjectBundle.ts
+++ b/frontend/src/features/project-shell/useProjectBundle.ts
@@ -60,11 +60,12 @@ function buildDocumentDetailCacheIds({
       keepIds.add(document.id);
     }
   }
+  const recentDocumentIdSet = new Set(recentDocumentIds);
   const orderedRecentIds = [
     ...recentDocumentIds,
     ...documents
       .map((document) => document.id)
-      .filter((documentId) => !recentDocumentIds.includes(documentId)),
+      .filter((documentId) => !recentDocumentIdSet.has(documentId)),
   ];
   let recentCount = 0;
   for (const documentId of orderedRecentIds) {

--- a/frontend/src/features/project-shell/useProjectBundle.ts
+++ b/frontend/src/features/project-shell/useProjectBundle.ts
@@ -6,7 +6,11 @@ import type {
 } from "../../api-contract";
 import type { DocumentListItem, ProjectBundle } from "../../types";
 import { deepClone } from "../../utils";
-import { DOCUMENT_PAGE_SIZE, DOCUMENT_WINDOW_SIZE } from "./projectShellConstants";
+import {
+  DOCUMENT_DETAIL_CACHE_RECENT_SIZE,
+  DOCUMENT_PAGE_SIZE,
+  DOCUMENT_WINDOW_SIZE,
+} from "./projectShellConstants";
 import {
   mergeDocumentScrollWindow,
   toDocumentListItem,
@@ -19,6 +23,61 @@ type DocumentPageRequest = boolean | "reset" | "next" | "previous";
 export type OnBundleLoaded = (bundle: ProjectBundle, firstDocId: string | null) => void;
 type SettingsSnapshot = Pick<ProjectBundle, "project" | "labels"> & { labelsRevision: string };
 type SettingsBundleDraft = Pick<ProjectBundle, "project" | "labels">;
+
+function isDocumentDirty(
+  document: DocumentRecord,
+  snapshotsById: Record<string, DocumentRecord>,
+) {
+  const snapshot = snapshotsById[document.id];
+  return Boolean(snapshot) && JSON.stringify(document) !== JSON.stringify(snapshot);
+}
+
+function moveDocumentToRecent(documentIds: string[], documentId: string) {
+  return [
+    documentId,
+    ...documentIds.filter((id) => id !== documentId),
+  ];
+}
+
+function buildDocumentDetailCacheIds({
+  documents,
+  snapshotsById,
+  selectedDocId,
+  recentDocumentIds,
+}: {
+  documents: DocumentRecord[];
+  snapshotsById: Record<string, DocumentRecord>;
+  selectedDocId: string | null;
+  recentDocumentIds: string[];
+}) {
+  const loadedIds = new Set(documents.map((document) => document.id));
+  const keepIds = new Set<string>();
+  if (selectedDocId && loadedIds.has(selectedDocId)) {
+    keepIds.add(selectedDocId);
+  }
+  for (const document of documents) {
+    if (isDocumentDirty(document, snapshotsById)) {
+      keepIds.add(document.id);
+    }
+  }
+  const orderedRecentIds = [
+    ...recentDocumentIds,
+    ...documents
+      .map((document) => document.id)
+      .filter((documentId) => !recentDocumentIds.includes(documentId)),
+  ];
+  let recentCount = 0;
+  for (const documentId of orderedRecentIds) {
+    if (loadedIds.has(documentId)) {
+      keepIds.add(documentId);
+      recentCount += 1;
+    }
+    if (recentCount >= DOCUMENT_DETAIL_CACHE_RECENT_SIZE) {
+      break;
+    }
+  }
+  return keepIds;
+}
 
 function buildDocumentWindowLookupOffsets(startOffset: number, total: number) {
   const maxOffset = Math.max(0, total - DOCUMENT_PAGE_SIZE);
@@ -77,6 +136,7 @@ export function useProjectBundle({
   const bundleLoadRequestIdRef = useRef(0);
   const documentLoadMoreRequestIdRef = useRef(0);
   const initialDocumentListLoadedRef = useRef(false);
+  const recentDocumentDetailIdsRef = useRef<string[]>([]);
 
   async function loadBundle(onLoaded?: OnBundleLoaded) {
     setLoading(true);
@@ -121,6 +181,7 @@ export function useProjectBundle({
           loadedDocuments.map((document) => [document.id, deepClone(document)]),
         ),
       );
+      recentDocumentDetailIdsRef.current = loadedDocuments.map((document) => document.id);
       setDocumentList(trimDocumentScrollWindow(documentsResponse.documents, "start"));
       setDocumentTotal(documentsResponse.total);
       setPendingDocumentTotal(documentsResponse.pending_total);
@@ -187,6 +248,53 @@ export function useProjectBundle({
       active = false;
     };
   }, [bundle, projectId, selectedDocId]);
+
+  useEffect(() => {
+    if (!bundle || !selectedDocId) {
+      return;
+    }
+    if (!bundle.documents.some((document) => document.id === selectedDocId)) {
+      return;
+    }
+    recentDocumentDetailIdsRef.current = moveDocumentToRecent(
+      recentDocumentDetailIdsRef.current,
+      selectedDocId,
+    );
+  }, [bundle, selectedDocId]);
+
+  useEffect(() => {
+    if (!bundle) {
+      return;
+    }
+    const keepIds = buildDocumentDetailCacheIds({
+      documents: bundle.documents,
+      snapshotsById: documentSnapshotsById,
+      selectedDocId,
+      recentDocumentIds: recentDocumentDetailIdsRef.current,
+    });
+    const nextDocuments = bundle.documents.filter((document) => keepIds.has(document.id));
+    const documentCacheChanged = nextDocuments.length !== bundle.documents.length;
+    const nextSnapshots = Object.fromEntries(
+      Object.entries(documentSnapshotsById).filter(([documentId]) => keepIds.has(documentId)),
+    );
+    const snapshotsChanged = Object.keys(nextSnapshots).length !== Object.keys(documentSnapshotsById).length;
+    recentDocumentDetailIdsRef.current = recentDocumentDetailIdsRef.current.filter((documentId) =>
+      keepIds.has(documentId),
+    );
+    if (documentCacheChanged) {
+      setBundle((current) =>
+        current
+          ? {
+              ...current,
+              documents: current.documents.filter((document) => keepIds.has(document.id)),
+            }
+          : current,
+      );
+    }
+    if (snapshotsChanged) {
+      setDocumentSnapshotsById(nextSnapshots);
+    }
+  }, [bundle, documentSnapshotsById, selectedDocId]);
 
   async function fetchDocumentPage(
     request: DocumentPageRequest,

--- a/frontend/src/test/useDocumentHistory.test.ts
+++ b/frontend/src/test/useDocumentHistory.test.ts
@@ -127,9 +127,11 @@ describe("useDocumentHistory", () => {
 
     expect(result.current.historyState.entries).toHaveLength(2);
 
-    rerender({
-      currentDocument: null,
-      currentDocumentSnapshot: null,
+    await act(async () => {
+      rerender({
+        currentDocument: null,
+        currentDocumentSnapshot: null,
+      });
     });
 
     expect(result.current.historyState.documentId).toBe("doc-1");

--- a/frontend/src/test/useDocumentHistory.test.ts
+++ b/frontend/src/test/useDocumentHistory.test.ts
@@ -34,6 +34,11 @@ function createBundle(document: DocumentRecord): ProjectBundle {
   };
 }
 
+type DocumentHistoryProps = {
+  currentDocument: DocumentRecord | null;
+  currentDocumentSnapshot: DocumentRecord | null;
+};
+
 describe("useDocumentHistory", () => {
   it("initializes with empty history and then resets when document is present", async () => {
     const doc = createDocument();
@@ -81,6 +86,55 @@ describe("useDocumentHistory", () => {
     expect(result.current.historyState.index).toBe(-1);
     expect(result.current.canUndo).toBe(false);
     expect(result.current.canRedo).toBe(false);
+  });
+
+  it("preserves history while the selected document is loading", async () => {
+    const doc = createDocument();
+    const bundle = createBundle(doc);
+    let currentBundle = bundle;
+    const setBundle = (updater: React.SetStateAction<ProjectBundle | null>) => {
+      if (typeof updater === "function") {
+        const next = updater(currentBundle);
+        if (next) currentBundle = next;
+      } else if (updater) {
+        currentBundle = updater;
+      }
+    };
+
+    const { result, rerender } = renderHook(
+      ({ currentDocument, currentDocumentSnapshot }: DocumentHistoryProps) =>
+        useDocumentHistory({
+          bundle: currentBundle,
+          setBundle,
+          currentDocument,
+          currentDocumentSnapshot,
+          view: "workspace",
+        }),
+      {
+        initialProps: {
+          currentDocument: currentBundle.documents[0],
+          currentDocumentSnapshot: currentBundle.documents[0],
+        } as DocumentHistoryProps,
+      },
+    );
+
+    await act(async () => {});
+    act(() => {
+      result.current.mutateCurrentDocument((draft) => {
+        draft.document_name = "Modified";
+      });
+    });
+
+    expect(result.current.historyState.entries).toHaveLength(2);
+
+    rerender({
+      currentDocument: null,
+      currentDocumentSnapshot: null,
+    });
+
+    expect(result.current.historyState.documentId).toBe("doc-1");
+    expect(result.current.historyState.entries).toHaveLength(2);
+    expect(result.current.historyState.index).toBe(1);
   });
 
   it("mutateCurrentDocument pushes to history and updates bundle", async () => {

--- a/frontend/src/test/useProjectBundle.test.ts
+++ b/frontend/src/test/useProjectBundle.test.ts
@@ -1,7 +1,11 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../api";
-import { DOCUMENT_PAGE_SIZE, DOCUMENT_WINDOW_SIZE } from "../features/project-shell/projectShellConstants";
+import {
+  DOCUMENT_DETAIL_CACHE_RECENT_SIZE,
+  DOCUMENT_PAGE_SIZE,
+  DOCUMENT_WINDOW_SIZE,
+} from "../features/project-shell/projectShellConstants";
 import { useProjectBundle } from "../features/project-shell/useProjectBundle";
 import type { DocumentRecord, DocumentSortValue, LabelRecord, ProjectRecord } from "../api-contract";
 import type { DocumentListItem } from "../types";
@@ -27,6 +31,10 @@ const labels: LabelRecord[] = [
   },
 ];
 const labelsRevision = "labels-revision-1";
+
+type SelectedDocumentProps = {
+  selectedDocId: string | null;
+};
 
 function createDocument(overrides: Partial<DocumentRecord> = {}): DocumentRecord {
   return {
@@ -322,6 +330,148 @@ describe("useProjectBundle", () => {
     expect(result.current.documentList).toHaveLength(1);
     expect(result.current.documentList[0].id).toBe("doc-2");
     expect(result.current.documentSnapshotsById["doc-1"]).toBeUndefined();
+  });
+
+  it("keeps selected document details within the recent document cache", async () => {
+    const documents = Array.from({ length: DOCUMENT_DETAIL_CACHE_RECENT_SIZE + 3 }, (_, index) =>
+      createDocument({
+        id: `doc-${index + 1}`,
+        document_name: `Doc ${index + 1}`,
+      }),
+    );
+    vi.spyOn(api, "getProject").mockResolvedValue(project);
+    vi.spyOn(api, "listLabels").mockResolvedValue({ labels: [], revision: labelsRevision });
+    vi.spyOn(api, "listDocuments").mockResolvedValue({
+      documents: documents.map((document) => createDocumentListItem({
+        id: document.id,
+        document_name: document.document_name,
+      })),
+      total: documents.length,
+      pending_total: documents.length,
+      offset: 0,
+      limit: DOCUMENT_PAGE_SIZE,
+      search: "",
+      sort: "created",
+    });
+    const getDocumentSpy = vi.spyOn(api, "getDocument").mockImplementation(async (_projectId, documentId) => {
+      const document = documents.find((item) => item.id === documentId);
+      if (!document) {
+        throw new Error("Document not found");
+      }
+      return document;
+    });
+
+    const { result, rerender } = renderHook(
+      ({ selectedDocId }: SelectedDocumentProps) =>
+        useProjectBundle({
+          projectId: "project-1",
+          searchQuery: "",
+          sortMode: "created",
+          selectedDocId,
+          showToast: makeShowToast(),
+        }),
+      { initialProps: { selectedDocId: null } as SelectedDocumentProps },
+    );
+
+    await act(async () => {
+      await result.current.loadBundle();
+    });
+
+    for (const document of documents.slice(1)) {
+      rerender({ selectedDocId: document.id });
+      await waitFor(() => {
+        expect(result.current.bundle?.documents.some((item) => item.id === document.id)).toBe(true);
+      });
+    }
+
+    expect(result.current.bundle?.documents).toHaveLength(DOCUMENT_DETAIL_CACHE_RECENT_SIZE);
+    expect(result.current.documentSnapshotsById["doc-1"]).toBeUndefined();
+    expect(result.current.documentSnapshotsById["doc-2"]).toBeUndefined();
+
+    const callsBeforeCacheHit = getDocumentSpy.mock.calls.length;
+    rerender({ selectedDocId: "doc-4" });
+    await waitFor(() => {
+      expect(result.current.bundle?.documents.some((item) => item.id === "doc-4")).toBe(true);
+    });
+    expect(getDocumentSpy).toHaveBeenCalledTimes(callsBeforeCacheHit);
+
+    rerender({ selectedDocId: "doc-2" });
+    await waitFor(() => {
+      expect(result.current.bundle?.documents.some((item) => item.id === "doc-2")).toBe(true);
+    });
+    expect(getDocumentSpy).toHaveBeenCalledTimes(callsBeforeCacheHit + 1);
+  });
+
+  it("does not evict dirty document details or their snapshots", async () => {
+    const documents = Array.from({ length: DOCUMENT_DETAIL_CACHE_RECENT_SIZE + 3 }, (_, index) =>
+      createDocument({
+        id: `doc-${index + 1}`,
+        document_name: `Doc ${index + 1}`,
+      }),
+    );
+    vi.spyOn(api, "getProject").mockResolvedValue(project);
+    vi.spyOn(api, "listLabels").mockResolvedValue({ labels: [], revision: labelsRevision });
+    vi.spyOn(api, "listDocuments").mockResolvedValue({
+      documents: documents.map((document) => createDocumentListItem({
+        id: document.id,
+        document_name: document.document_name,
+      })),
+      total: documents.length,
+      pending_total: documents.length,
+      offset: 0,
+      limit: DOCUMENT_PAGE_SIZE,
+      search: "",
+      sort: "created",
+    });
+    vi.spyOn(api, "getDocument").mockImplementation(async (_projectId, documentId) => {
+      const document = documents.find((item) => item.id === documentId);
+      if (!document) {
+        throw new Error("Document not found");
+      }
+      return document;
+    });
+
+    const { result, rerender } = renderHook(
+      ({ selectedDocId }: SelectedDocumentProps) =>
+        useProjectBundle({
+          projectId: "project-1",
+          searchQuery: "",
+          sortMode: "created",
+          selectedDocId,
+          showToast: makeShowToast(),
+        }),
+      { initialProps: { selectedDocId: "doc-1" } },
+    );
+
+    await act(async () => {
+      await result.current.loadBundle();
+    });
+    act(() => {
+      result.current.setBundle((current) =>
+        current
+          ? {
+              ...current,
+              documents: current.documents.map((document) =>
+                document.id === "doc-1"
+                  ? { ...document, text: "Dirty text" }
+                  : document,
+              ),
+            }
+          : current,
+      );
+    });
+
+    for (const document of documents.slice(1)) {
+      rerender({ selectedDocId: document.id });
+      await waitFor(() => {
+        expect(result.current.bundle?.documents.some((item) => item.id === document.id)).toBe(true);
+      });
+    }
+
+    expect(result.current.bundle?.documents.some((document) => document.id === "doc-1")).toBe(true);
+    expect(result.current.documentSnapshotsById["doc-1"]).toBeDefined();
+    expect(result.current.bundle?.documents).toHaveLength(DOCUMENT_DETAIL_CACHE_RECENT_SIZE + 1);
+    expect(result.current.documentSnapshotsById["doc-2"]).toBeUndefined();
   });
 
   it("fetchDocumentPage appends to document list when not resetting", async () => {

--- a/frontend/src/test/useProjectBundle.test.ts
+++ b/frontend/src/test/useProjectBundle.test.ts
@@ -378,7 +378,9 @@ describe("useProjectBundle", () => {
     });
 
     for (const document of documents.slice(1)) {
-      rerender({ selectedDocId: document.id });
+      await act(async () => {
+        rerender({ selectedDocId: document.id });
+      });
       await waitFor(() => {
         expect(result.current.bundle?.documents.some((item) => item.id === document.id)).toBe(true);
       });
@@ -389,13 +391,17 @@ describe("useProjectBundle", () => {
     expect(result.current.documentSnapshotsById["doc-2"]).toBeUndefined();
 
     const callsBeforeCacheHit = getDocumentSpy.mock.calls.length;
-    rerender({ selectedDocId: "doc-4" });
+    await act(async () => {
+      rerender({ selectedDocId: "doc-4" });
+    });
     await waitFor(() => {
       expect(result.current.bundle?.documents.some((item) => item.id === "doc-4")).toBe(true);
     });
     expect(getDocumentSpy).toHaveBeenCalledTimes(callsBeforeCacheHit);
 
-    rerender({ selectedDocId: "doc-2" });
+    await act(async () => {
+      rerender({ selectedDocId: "doc-2" });
+    });
     await waitFor(() => {
       expect(result.current.bundle?.documents.some((item) => item.id === "doc-2")).toBe(true);
     });


### PR DESCRIPTION
## 概要
- Document詳細cacheを current / dirty / recent documents に限定
- cache eviction時にsnapshot mapも同じ方針で破棄
- selected documentのcache hit / evictionとdirty document保護の単体テストを追加
- Workspace仕様にDocument詳細cache方針を追記

## 検証
- npm test -- --run src/test/useProjectBundle.test.ts src/test/useDocumentHistory.test.ts
- npm run build
- npm test -- --run
- npm test -- --run src/test/useProjectBundle.test.ts src/test/useDocumentHistory.test.ts src/test/projectShellPendingChanges.test.tsx
- git diff --check origin/main
- subagentセルフレビュー: 指摘なし

Closes #46