### PR TITLE
関連例検索用の複合インデックスを追加

### DIFF
--- a/backend/src/layered_span_studio_backend/main.py
+++ b/backend/src/layered_span_studio_backend/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from layered_span_studio_backend.api.router import router as api_router
 from layered_span_studio_backend.core.config import Settings, get_settings
+from layered_span_studio_backend.repositories.projects import ensure_project_dbs
 from layered_span_studio_backend.repositories.users import ensure_users_db
 from layered_span_studio_backend.version import get_app_version
 
@@ -18,6 +19,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app.state.settings = settings
     ensure_users_db(settings)
+    ensure_project_dbs(settings)
 
     app.add_middleware(
         CORSMiddleware,

--- a/backend/src/layered_span_studio_backend/main.py
+++ b/backend/src/layered_span_studio_backend/main.py
@@ -5,7 +5,6 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from layered_span_studio_backend.api.router import router as api_router
 from layered_span_studio_backend.core.config import Settings, get_settings
-from layered_span_studio_backend.repositories.projects import ensure_project_dbs
 from layered_span_studio_backend.repositories.users import ensure_users_db
 from layered_span_studio_backend.version import get_app_version
 
@@ -19,7 +18,6 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app.state.settings = settings
     ensure_users_db(settings)
-    ensure_project_dbs(settings)
 
     app.add_middleware(
         CORSMiddleware,

--- a/backend/src/layered_span_studio_backend/repositories/projects.py
+++ b/backend/src/layered_span_studio_backend/repositories/projects.py
@@ -12,7 +12,14 @@ from sqlalchemy.exc import OperationalError
 
 from layered_span_studio_backend.core.config import Settings
 from layered_span_studio_backend.repositories.label_sync import load_label_rows, sync_labels
-from layered_span_studio_backend.storage.project_db import documents_table, get_project_engine, init_project_db, labels_table, project_table
+from layered_span_studio_backend.storage.project_db import (
+    documents_table,
+    ensure_project_indexes,
+    get_project_engine,
+    init_project_db,
+    labels_table,
+    project_table,
+)
 from layered_span_studio_backend.utils.json_utils import decode_meta, encode_meta
 
 
@@ -140,6 +147,17 @@ def list_projects(settings: Settings) -> List[Dict[str, Any]]:
         )
     projects.sort(key=_project_sort_key)
     return projects
+
+
+def ensure_project_dbs(settings: Settings) -> None:
+    if not settings.projects_dir.exists():
+        return
+    for entry in settings.projects_dir.iterdir():
+        db_path = entry / PROJECT_DB_FILENAME
+        if not entry.is_dir() or not db_path.exists():
+            continue
+        engine = get_project_engine(str(db_path))
+        ensure_project_indexes(engine)
 
 
 def get_project(settings: Settings, project_id: str) -> Optional[Dict[str, Any]]:

--- a/backend/src/layered_span_studio_backend/repositories/projects.py
+++ b/backend/src/layered_span_studio_backend/repositories/projects.py
@@ -4,6 +4,7 @@ import shutil
 import time
 import uuid
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -149,15 +150,21 @@ def list_projects(settings: Settings) -> List[Dict[str, Any]]:
     return projects
 
 
-def ensure_project_dbs(settings: Settings) -> None:
-    if not settings.projects_dir.exists():
-        return
-    for entry in settings.projects_dir.iterdir():
-        db_path = entry / PROJECT_DB_FILENAME
-        if not entry.is_dir() or not db_path.exists():
-            continue
-        engine = get_project_engine(str(db_path))
-        ensure_project_indexes(engine)
+def _ensure_project_indexes_with_retry(db_path: Path) -> None:
+    engine = get_project_engine(str(db_path))
+    for attempt in range(len(PROJECT_SCHEMA_RETRY_DELAYS) + 1):
+        try:
+            ensure_project_indexes(engine)
+            return
+        except OperationalError as exc:
+            if attempt == len(PROJECT_SCHEMA_RETRY_DELAYS) or not _is_sqlite_lock_error(exc):
+                raise
+            time.sleep(PROJECT_SCHEMA_RETRY_DELAYS[attempt])
+
+
+@lru_cache
+def _ensure_project_indexes_once(db_path: str) -> None:
+    _ensure_project_indexes_with_retry(Path(db_path))
 
 
 def get_project(settings: Settings, project_id: str) -> Optional[Dict[str, Any]]:
@@ -330,4 +337,7 @@ def delete_project(settings: Settings, project_id: str) -> bool:
 
 
 def project_db_path(settings: Settings, project_id: str) -> Path:
-    return _project_db_path(settings, project_id)
+    db_path = _project_db_path(settings, project_id)
+    if db_path.exists():
+        _ensure_project_indexes_once(str(db_path))
+    return db_path

--- a/backend/src/layered_span_studio_backend/storage/project_db.py
+++ b/backend/src/layered_span_studio_backend/storage/project_db.py
@@ -133,5 +133,12 @@ def init_project_db(db_path: Path) -> None:
 
 def ensure_project_indexes(engine: Engine) -> None:
     with engine.begin() as conn:
+        has_annotations_table = (
+            conn.exec_driver_sql("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'annotations'")
+            .first()
+            is not None
+        )
+        if not has_annotations_table:
+            return
         for ddl in PROJECT_INDEX_DDL:
             conn.exec_driver_sql(ddl)

--- a/backend/src/layered_span_studio_backend/storage/project_db.py
+++ b/backend/src/layered_span_studio_backend/storage/project_db.py
@@ -88,6 +88,18 @@ Index("idx_annotations_document", annotations_table.c.document_id)
 Index("idx_annotations_label", annotations_table.c.label_id)
 Index("idx_annotations_status", annotations_table.c.status)
 Index("idx_annotations_position", annotations_table.c.document_id, annotations_table.c.start, annotations_table.c.end)
+RELATED_EXAMPLE_INDEX_COLUMNS = (
+    ("idx_annotations_surface_search", ("span_text", "status", "document_id", "label_id", "start", "id")),
+    ("idx_annotations_label_surface_groups", ("label_id", "status", "span_text", "document_id", "start", "id")),
+)
+
+for index_name, column_names in RELATED_EXAMPLE_INDEX_COLUMNS:
+    Index(index_name, *(annotations_table.c[column_name] for column_name in column_names))
+
+PROJECT_INDEX_DDL = tuple(
+    f"CREATE INDEX IF NOT EXISTS {index_name} ON annotations ({', '.join(column_names)})"
+    for index_name, column_names in RELATED_EXAMPLE_INDEX_COLUMNS
+)
 
 
 def _engine_for_path(path: Path) -> Engine:
@@ -116,3 +128,10 @@ def init_project_db(db_path: Path) -> None:
     db_path.parent.mkdir(parents=True, exist_ok=True)
     engine = _engine_for_path(db_path)
     metadata.create_all(engine)
+    ensure_project_indexes(engine)
+
+
+def ensure_project_indexes(engine: Engine) -> None:
+    with engine.begin() as conn:
+        for ddl in PROJECT_INDEX_DDL:
+            conn.exec_driver_sql(ddl)

--- a/backend/tests/test_annotations.py
+++ b/backend/tests/test_annotations.py
@@ -5,6 +5,9 @@ from typing import Any
 from fastapi.testclient import TestClient
 
 from conftest import create_label_via_sync
+from layered_span_studio_backend.core.config import Settings
+from layered_span_studio_backend.repositories.projects import project_db_path
+from layered_span_studio_backend.storage.project_db import get_project_engine
 
 JSONDict = dict[str, Any]
 
@@ -332,6 +335,42 @@ def test_search_annotations_does_not_normalize_surface_text(
     payload = response.json()
     assert payload["total"] == 1
     assert payload["items"][0]["span_text"] == "COVID-19"
+
+
+def test_search_annotations_query_plan_uses_surface_search_index(
+    client: TestClient, auth_headers: dict[str, str], settings: Settings
+) -> None:
+    project, label, doc = _setup(client, auth_headers)
+    client.post(
+        f"/projects/{project['id']}/documents/{doc['id']}/annotations",
+        json={
+            "label_id": label["id"],
+            "start": 0,
+            "end": 5,
+            "span_text": "Hello",
+            "comment": "",
+            "status": "verified",
+        },
+        headers=auth_headers,
+    )
+    engine = get_project_engine(str(project_db_path(settings, project["id"])))
+
+    with engine.connect() as conn:
+        plan_rows = conn.exec_driver_sql(
+            """
+            EXPLAIN QUERY PLAN
+            SELECT count(*)
+            FROM annotations
+            JOIN documents ON annotations.document_id = documents.id
+            JOIN labels ON annotations.label_id = labels.id
+            WHERE documents.project_id = ?
+              AND annotations.status IN ('pending', 'verified')
+              AND annotations.span_text = ?
+            """,
+            (project["id"], "Hello"),
+        ).mappings().all()
+
+    assert any("idx_annotations_surface_search" in row["detail"] for row in plan_rows)
 
 
 def test_search_annotations_pages_and_sorts_in_sql(

--- a/backend/tests/test_labels.py
+++ b/backend/tests/test_labels.py
@@ -830,6 +830,124 @@ def test_label_surface_groups_ignore_empty_surface_text(
     assert [item["surface_text"] for item in payload["items"]] == ["alpha"]
 
 
+def test_label_surface_groups_query_plan_uses_label_surface_index(
+    client: TestClient, auth_headers: dict[str, str], settings: Settings
+) -> None:
+    project = client.post(
+        "/projects",
+        json={"name": "Surface Plan Project", "description": "desc", "meta": {}},
+        headers=auth_headers,
+    ).json()
+    label = create_label_via_sync(
+        client, auth_headers, project["id"], name="Disease", color="#AA3322", description="desc", meta={}
+    )
+    doc = client.post(
+        f"/projects/{project['id']}/documents",
+        json={"document_name": "DocA", "text": "alpha", "meta": {}},
+        headers=auth_headers,
+    ).json()
+    _insert_annotation_row(
+        settings,
+        project["id"],
+        annotation_id="ann-alpha",
+        document_id=doc["id"],
+        label_id=label["id"],
+        start=0,
+        end=5,
+        span_text="alpha",
+    )
+    engine = get_project_engine(str(project_db_path(settings, project["id"])))
+
+    with engine.connect() as conn:
+        plan_rows = conn.exec_driver_sql(
+            """
+            EXPLAIN QUERY PLAN
+            SELECT count(distinct annotations.span_text)
+            FROM annotations
+            JOIN documents ON annotations.document_id = documents.id
+            WHERE documents.project_id = ?
+              AND annotations.label_id = ?
+              AND annotations.status IN ('pending', 'verified')
+              AND annotations.span_text != ''
+            """,
+            (project["id"], label["id"]),
+        ).mappings().all()
+
+    assert any("idx_annotations_label_surface_groups" in row["detail"] for row in plan_rows)
+
+
+def test_label_surface_groups_representative_query_plan_uses_label_surface_index(
+    client: TestClient, auth_headers: dict[str, str], settings: Settings
+) -> None:
+    project = client.post(
+        "/projects",
+        json={"name": "Surface Representative Plan Project", "description": "desc", "meta": {}},
+        headers=auth_headers,
+    ).json()
+    label = create_label_via_sync(
+        client, auth_headers, project["id"], name="Disease", color="#AA3322", description="desc", meta={}
+    )
+    doc = client.post(
+        f"/projects/{project['id']}/documents",
+        json={"document_name": "DocA", "text": "alpha", "meta": {}},
+        headers=auth_headers,
+    ).json()
+    _insert_annotation_row(
+        settings,
+        project["id"],
+        annotation_id="ann-alpha",
+        document_id=doc["id"],
+        label_id=label["id"],
+        start=0,
+        end=5,
+        span_text="alpha",
+    )
+    engine = get_project_engine(str(project_db_path(settings, project["id"])))
+
+    with engine.connect() as conn:
+        plan_rows = conn.exec_driver_sql(
+            """
+            EXPLAIN QUERY PLAN
+            WITH surface_group_candidates AS (
+                SELECT
+                    annotations.id AS annotation_id,
+                    annotations.document_id,
+                    documents.document_name,
+                    documents.text AS document_text,
+                    annotations.span_text AS surface_text,
+                    annotations.start,
+                    annotations.end,
+                    annotations.status,
+                    CASE WHEN annotations.status = 'verified' THEN 0 ELSE 1 END AS representative_rank,
+                    count(*) OVER (PARTITION BY annotations.span_text) AS duplicate_count,
+                    row_number() OVER (
+                        PARTITION BY annotations.span_text
+                        ORDER BY
+                            CASE WHEN annotations.status = 'verified' THEN 0 ELSE 1 END ASC,
+                            documents.document_name ASC,
+                            annotations.start ASC,
+                            annotations.id ASC
+                    ) AS surface_rank
+                FROM annotations
+                JOIN documents ON annotations.document_id = documents.id
+                WHERE documents.project_id = ?
+                  AND annotations.label_id = ?
+                  AND annotations.status IN ('pending', 'verified')
+                  AND annotations.span_text != ''
+            )
+            SELECT surface_text, duplicate_count, annotation_id
+            FROM surface_group_candidates
+            WHERE surface_rank = 1
+            ORDER BY representative_rank ASC, document_name ASC, start ASC, annotation_id ASC
+            LIMIT 20 OFFSET 0
+            """,
+            (project["id"], label["id"]),
+        ).mappings().all()
+
+    assert any("idx_annotations_label_surface_groups" in row["detail"] for row in plan_rows)
+    assert not any(row["detail"] == "SCAN annotations" for row in plan_rows)
+
+
 def test_label_surface_groups_do_not_normalize_surface_text(
     client: TestClient, auth_headers: dict[str, str]
 ) -> None:

--- a/backend/tests/test_project_schema.py
+++ b/backend/tests/test_project_schema.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from layered_span_studio_backend.core.config import Settings
+from layered_span_studio_backend.main import create_app
+from layered_span_studio_backend.repositories import projects as projects_repo
+from layered_span_studio_backend.storage.project_db import get_project_engine, init_project_db
+
+
+RELATED_EXAMPLE_INDEXES = {
+    "idx_annotations_surface_search",
+    "idx_annotations_label_surface_groups",
+}
+
+RELATED_EXAMPLE_INDEX_COLUMNS = {
+    "idx_annotations_surface_search": ["span_text", "status", "document_id", "label_id", "start", "id"],
+    "idx_annotations_label_surface_groups": ["label_id", "status", "span_text", "document_id", "start", "id"],
+}
+
+
+def _annotation_index_names(db_path: Path) -> set[str]:
+    engine = get_project_engine(str(db_path))
+    with engine.connect() as conn:
+        rows = conn.exec_driver_sql("PRAGMA index_list('annotations')").mappings().all()
+    return {row["name"] for row in rows}
+
+
+def _annotation_index_columns(db_path: Path, index_name: str) -> list[str]:
+    engine = get_project_engine(str(db_path))
+    with engine.connect() as conn:
+        rows = conn.exec_driver_sql(f"PRAGMA index_info('{index_name}')").mappings().all()
+    return [row["name"] for row in rows]
+
+
+def test_init_project_db_creates_related_example_indexes(tmp_path: Path) -> None:
+    db_path = tmp_path / "project.db"
+
+    init_project_db(db_path)
+
+    assert RELATED_EXAMPLE_INDEXES <= _annotation_index_names(db_path)
+
+
+def test_related_example_indexes_keep_expected_column_order(tmp_path: Path) -> None:
+    db_path = tmp_path / "project.db"
+
+    init_project_db(db_path)
+
+    assert {
+        index_name: _annotation_index_columns(db_path, index_name)
+        for index_name in RELATED_EXAMPLE_INDEX_COLUMNS
+    } == RELATED_EXAMPLE_INDEX_COLUMNS
+
+
+def test_create_app_migrates_existing_project_related_example_indexes(settings: Settings) -> None:
+    project = projects_repo.create_project(settings, "Existing Project", "desc", {})
+    db_path = projects_repo.project_db_path(settings, project["id"])
+    engine = get_project_engine(str(db_path))
+    with engine.begin() as conn:
+        for index_name in RELATED_EXAMPLE_INDEXES:
+            conn.exec_driver_sql(f"DROP INDEX IF EXISTS {index_name}")
+
+    create_app(settings)
+
+    assert RELATED_EXAMPLE_INDEXES <= _annotation_index_names(db_path)

--- a/backend/tests/test_project_schema.py
+++ b/backend/tests/test_project_schema.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+from sqlalchemy.exc import OperationalError
+
 from layered_span_studio_backend.core.config import Settings
 from layered_span_studio_backend.main import create_app
 from layered_span_studio_backend.repositories import projects as projects_repo
@@ -52,14 +55,69 @@ def test_related_example_indexes_keep_expected_column_order(tmp_path: Path) -> N
     } == RELATED_EXAMPLE_INDEX_COLUMNS
 
 
-def test_create_app_migrates_existing_project_related_example_indexes(settings: Settings) -> None:
+def test_project_db_path_migrates_existing_project_related_example_indexes(settings: Settings) -> None:
     project = projects_repo.create_project(settings, "Existing Project", "desc", {})
     db_path = projects_repo.project_db_path(settings, project["id"])
     engine = get_project_engine(str(db_path))
     with engine.begin() as conn:
         for index_name in RELATED_EXAMPLE_INDEXES:
             conn.exec_driver_sql(f"DROP INDEX IF EXISTS {index_name}")
+    projects_repo._ensure_project_indexes_once.cache_clear()
+
+    projects_repo.project_db_path(settings, project["id"])
+
+    assert RELATED_EXAMPLE_INDEXES <= _annotation_index_names(db_path)
+
+
+def test_create_app_does_not_block_on_existing_project_index_migration(settings: Settings) -> None:
+    project = projects_repo.create_project(settings, "Startup Project", "desc", {})
+    db_path = projects_repo.project_db_path(settings, project["id"])
+    engine = get_project_engine(str(db_path))
+    with engine.begin() as conn:
+        for index_name in RELATED_EXAMPLE_INDEXES:
+            conn.exec_driver_sql(f"DROP INDEX IF EXISTS {index_name}")
+    projects_repo._ensure_project_indexes_once.cache_clear()
 
     create_app(settings)
 
-    assert RELATED_EXAMPLE_INDEXES <= _annotation_index_names(db_path)
+    assert not RELATED_EXAMPLE_INDEXES <= _annotation_index_names(db_path)
+
+
+def test_project_db_path_retries_related_example_index_migration(
+    settings: Settings, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = projects_repo.create_project(settings, "Retry Project", "desc", {})
+    db_path = projects_repo.project_db_path(settings, project["id"])
+    projects_repo._ensure_project_indexes_once.cache_clear()
+    attempts = 0
+    real_ensure_project_indexes = projects_repo.ensure_project_indexes
+
+    def flaky_ensure_project_indexes(engine) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OperationalError("CREATE INDEX", {}, Exception("database is locked"))
+        real_ensure_project_indexes(engine)
+
+    monkeypatch.setattr(projects_repo, "ensure_project_indexes", flaky_ensure_project_indexes)
+
+    projects_repo.project_db_path(settings, project["id"])
+
+    assert attempts == 2
+
+
+def test_project_db_path_skips_related_example_indexes_when_annotations_table_is_missing(
+    settings: Settings,
+) -> None:
+    project_id = "legacy-project-without-annotations"
+    db_path = settings.projects_dir / project_id / "database.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    engine = get_project_engine(str(db_path))
+    with engine.begin() as conn:
+        conn.exec_driver_sql(
+            "CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, meta TEXT, created_at TEXT NOT NULL)"
+        )
+
+    projects_repo._ensure_project_indexes_once.cache_clear()
+
+    assert projects_repo.project_db_path(settings, project_id) == db_path

--- a/docs/backend/database-schema.md
+++ b/docs/backend/database-schema.md
@@ -602,7 +602,7 @@ UUID形式のIDを使用しているため、ID衝突の心配なくインポー
 
 補足:
 - `span_text` 単独ではなく、関連例 API の主要条件に合わせた composite index を使います。これにより同一表層検索と label surface group の query plan が annotation 全体走査に寄りにくくなります。
-- 既存 project DB はアプリ起動時に `CREATE INDEX IF NOT EXISTS` で移行されます。
+- 既存 project DB は project DB 初回アクセス時に `CREATE INDEX IF NOT EXISTS` で移行されます。SQLite lock が一時的に発生した場合は短い retry を行います。
 - `surface-groups` や `annotations/search` は SQL 側で絞り込み・集約・ページングを行います。total count も同じ composite index を利用する前提です。
 
 ### スケーラビリティ

--- a/docs/backend/database-schema.md
+++ b/docs/backend/database-schema.md
@@ -276,6 +276,8 @@ CREATE INDEX idx_annotations_document ON annotations(document_id);
 CREATE INDEX idx_annotations_label ON annotations(label_id);
 CREATE INDEX idx_annotations_status ON annotations(status);
 CREATE INDEX idx_annotations_position ON annotations(document_id, start, end);
+CREATE INDEX idx_annotations_surface_search ON annotations(span_text, status, document_id, label_id, start, id);
+CREATE INDEX idx_annotations_label_surface_groups ON annotations(label_id, status, span_text, document_id, start, id);
 ```
 
 | カラム | 型 | NULL | 説明 |
@@ -331,7 +333,8 @@ CREATE TABLE IF NOT EXISTS project (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL,
     description TEXT,
-    meta TEXT
+    meta TEXT,
+    created_at TEXT NOT NULL
 );
 
 -- labels テーブル
@@ -343,6 +346,7 @@ CREATE TABLE IF NOT EXISTS labels (
     description TEXT NOT NULL,
     shortcut TEXT,
     meta TEXT,
+    display_order INTEGER,
     FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE CASCADE
 );
 
@@ -390,6 +394,10 @@ CREATE INDEX IF NOT EXISTS idx_annotations_document ON annotations(document_id);
 CREATE INDEX IF NOT EXISTS idx_annotations_label ON annotations(label_id);
 CREATE INDEX IF NOT EXISTS idx_annotations_status ON annotations(status);
 CREATE INDEX IF NOT EXISTS idx_annotations_position ON annotations(document_id, start, end);
+CREATE INDEX IF NOT EXISTS idx_annotations_surface_search
+    ON annotations(span_text, status, document_id, label_id, start, id);
+CREATE INDEX IF NOT EXISTS idx_annotations_label_surface_groups
+    ON annotations(label_id, status, span_text, document_id, start, id);
 ```
 
 ## 主要クエリ
@@ -589,11 +597,13 @@ UUID形式のIDを使用しているため、ID衝突の心配なくインポー
 - `idx_annotations_label`: 特定ラベルのアノテーション検索
 - `idx_annotations_status`: 未確認/確認済みの絞り込み
 - `idx_annotations_position`: 位置ベースの検索
+- `idx_annotations_surface_search`: `annotations/search` の `span_text` 完全一致、`status` 絞り込み、document/label join の軽量化
+- `idx_annotations_label_surface_groups`: label surface group の `label_id` / `status` / `span_text` 絞り込みと表層集約の軽量化
 
 補足:
-- `span_text` 向けの専用インデックスは追加しません。annotation は追加頻度が高く、書き込みコストと運用複雑性を増やしたくないためです。
-- `surface-groups` や `annotations/search` のようなラベル別検索・集約は、まず SQL 側で絞り込み・集約・ページングを行うことで対応します。
-- 専用インデックスの追加は、実運用での観測結果が必要になった時点で別判断とします。
+- `span_text` 単独ではなく、関連例 API の主要条件に合わせた composite index を使います。これにより同一表層検索と label surface group の query plan が annotation 全体走査に寄りにくくなります。
+- 既存 project DB はアプリ起動時に `CREATE INDEX IF NOT EXISTS` で移行されます。
+- `surface-groups` や `annotations/search` は SQL 側で絞り込み・集約・ページングを行います。total count も同じ composite index を利用する前提です。
 
 ### スケーラビリティ
 


### PR DESCRIPTION
## 概要
- 同一表層検索向けに `idx_annotations_surface_search` を追加
- label surface group 向けに `idx_annotations_label_surface_groups` を追加
- 既存 project DB 起動時に `CREATE INDEX IF NOT EXISTS` で移行する処理を追加
- query plan が追加 index を利用することを backend テストで確認
- DB schema docs を更新

## 補足
- issue コメントの方針に従い、API / UI / cache / materialized table は変更していない
- frontend は既存の request id による stale response 抑止を確認し、追加実装なしとした
- 手元の既存 `backend/data/projects/*/database.db` には migration 実行済み

## 確認
- `cd backend && uv run pytest`（117 passed）
- `cd frontend && npm run test`（179 passed）
- `cd frontend && npm run build`

Closes #44