### PR TITLE
自動DB変換ロジックを削除

### DIFF
--- a/backend/src/layered_span_studio_backend/main.py
+++ b/backend/src/layered_span_studio_backend/main.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, status
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from layered_span_studio_backend.api.router import router as api_router
 from layered_span_studio_backend.core.config import Settings, get_settings
+from layered_span_studio_backend.repositories.projects import ProjectDatabaseMigrationRequired
 from layered_span_studio_backend.repositories.users import ensure_users_db
 from layered_span_studio_backend.version import get_app_version
+
+
+def _project_database_migration_required_handler(
+    _request: Request,
+    exc: ProjectDatabaseMigrationRequired,
+) -> JSONResponse:
+    return JSONResponse(status_code=status.HTTP_409_CONFLICT, content={"detail": str(exc)})
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
@@ -18,6 +27,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app.state.settings = settings
     ensure_users_db(settings)
+    app.add_exception_handler(ProjectDatabaseMigrationRequired, _project_database_migration_required_handler)
 
     app.add_middleware(
         CORSMiddleware,

--- a/backend/src/layered_span_studio_backend/repositories/label_sync.py
+++ b/backend/src/layered_span_studio_backend/repositories/label_sync.py
@@ -4,22 +4,10 @@ import uuid
 from typing import Any, Dict, List, Sequence
 
 from sqlalchemy import func, select
-from sqlalchemy.exc import OperationalError
 from sqlalchemy.engine import Connection, RowMapping
 
 from layered_span_studio_backend.storage.project_db import labels_table
 from layered_span_studio_backend.utils.json_utils import encode_meta
-
-
-def _ensure_display_order_column_exists(conn: Connection) -> None:
-    columns = {row["name"] for row in conn.exec_driver_sql("PRAGMA table_info(labels)").mappings()}
-    if "display_order" in columns:
-        return
-    try:
-        conn.exec_driver_sql("ALTER TABLE labels ADD COLUMN display_order INTEGER")
-    except OperationalError as exc:
-        if "duplicate column name" not in str(exc).lower():
-            raise
 
 
 def _current_max_display_order(conn: Connection, project_id: str) -> int | None:
@@ -32,39 +20,12 @@ def _current_max_display_order(conn: Connection, project_id: str) -> int | None:
     return int(current_max) if current_max is not None else None
 
 
-def _backfill_missing_display_orders(conn: Connection, project_id: str | None = None) -> None:
-    query = select(labels_table.c.id, labels_table.c.project_id).where(labels_table.c.display_order.is_(None))
-    if project_id is not None:
-        query = query.where(labels_table.c.project_id == project_id)
-    rows = conn.execute(query.order_by(labels_table.c.name.asc(), labels_table.c.id.asc())).mappings().all()
-    next_order_by_project: dict[str, int] = {}
-    for row in rows:
-        row_project_id = row["project_id"]
-        if row_project_id not in next_order_by_project:
-            current_max = _current_max_display_order(conn, row_project_id)
-            next_order_by_project[row_project_id] = current_max + 1 if current_max is not None else 0
-        display_order = next_order_by_project[row_project_id]
-        conn.execute(
-            labels_table.update()
-            .where(labels_table.c.id == row["id"])
-            .values(display_order=display_order)
-        )
-        next_order_by_project[row_project_id] = display_order + 1
-
-
-def ensure_label_display_order_column(conn: Connection, project_id: str | None = None) -> None:
-    _ensure_display_order_column_exists(conn)
-    _backfill_missing_display_orders(conn, project_id)
-
-
 def next_label_display_order(conn: Connection, project_id: str) -> int:
-    ensure_label_display_order_column(conn, project_id)
     current_max = _current_max_display_order(conn, project_id)
     return current_max + 1 if current_max is not None else 0
 
 
 def load_label_rows(conn: Connection, project_id: str) -> Sequence[RowMapping]:
-    ensure_label_display_order_column(conn, project_id)
     return conn.execute(
         select(labels_table)
         .where(labels_table.c.project_id == project_id)
@@ -78,7 +39,6 @@ def sync_labels(
     items: List[Dict[str, Any]],
     existing_rows: Sequence[RowMapping] | None = None,
 ) -> None:
-    ensure_label_display_order_column(conn, project_id)
     rows = list(existing_rows) if existing_rows is not None else list(load_label_rows(conn, project_id))
     existing_ids = {row["id"] for row in rows}
     requested_ids = {item["id"] for item in items if item.get("id")}

--- a/backend/src/layered_span_studio_backend/repositories/labels.py
+++ b/backend/src/layered_span_studio_backend/repositories/labels.py
@@ -9,7 +9,6 @@ from sqlalchemy import case, func, select
 
 from layered_span_studio_backend.core.config import Settings
 from layered_span_studio_backend.repositories.label_sync import (
-    ensure_label_display_order_column,
     load_label_rows,
     next_label_display_order,
     sync_labels,
@@ -89,7 +88,6 @@ def get_label(settings: Settings, project_id: str, label_id: str) -> Optional[Di
     engine = get_project_engine(str(db_path))
     project_name = _project_name(settings, project_id)
     with engine.begin() as conn:
-        ensure_label_display_order_column(conn, project_id)
         row = (
             conn.execute(
                 select(labels_table).where(
@@ -119,7 +117,6 @@ def get_label_by_name(settings: Settings, project_id: str, name: str) -> Optiona
     engine = get_project_engine(str(db_path))
     project_name = _project_name(settings, project_id)
     with engine.begin() as conn:
-        ensure_label_display_order_column(conn, project_id)
         row = (
             conn.execute(
                 select(labels_table).where(

--- a/backend/src/layered_span_studio_backend/repositories/projects.py
+++ b/backend/src/layered_span_studio_backend/repositories/projects.py
@@ -21,6 +21,11 @@ from layered_span_studio_backend.utils.json_utils import decode_meta, encode_met
 
 
 PROJECT_DB_FILENAME = "database.db"
+PROJECT_DB_MIGRATION_MESSAGE = "Project database migration is required. Run the explicit project DB migration."
+
+
+class ProjectDatabaseMigrationRequired(RuntimeError):
+    pass
 
 
 def _project_dir(settings: Settings, project_id: str) -> Path:
@@ -47,6 +52,18 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _require_current_project_schema(conn) -> None:
+    project_columns = {row["name"] for row in conn.exec_driver_sql("PRAGMA table_info(project)").mappings()}
+    label_columns = {row["name"] for row in conn.exec_driver_sql("PRAGMA table_info(labels)").mappings()}
+    if "created_at" not in project_columns or "display_order" not in label_columns:
+        raise ProjectDatabaseMigrationRequired(PROJECT_DB_MIGRATION_MESSAGE)
+
+
+def _require_created_at(row: Dict[str, Any] | Any) -> None:
+    if not row["created_at"]:
+        raise ProjectDatabaseMigrationRequired(PROJECT_DB_MIGRATION_MESSAGE)
+
+
 def _project_sort_key(project: Dict[str, Any]) -> tuple[Any, ...]:
     summary = project["summary"]
     updated_at_timestamp = _parse_timestamp(summary["updated_at"])
@@ -70,9 +87,11 @@ def list_projects(settings: Settings) -> List[Dict[str, Any]]:
             continue
         engine = get_project_engine(str(db_path))
         with engine.begin() as conn:
+            _require_current_project_schema(conn)
             row = conn.execute(select(project_table)).mappings().first()
             if not row:
                 continue
+            _require_created_at(row)
 
             labels_count = conn.execute(select(func.count()).select_from(labels_table)).scalar_one()
             documents_count = conn.execute(select(func.count()).select_from(documents_table)).scalar_one()
@@ -106,9 +125,11 @@ def get_project(settings: Settings, project_id: str) -> Optional[Dict[str, Any]]
         return None
     engine = get_project_engine(str(db_path))
     with engine.begin() as conn:
+        _require_current_project_schema(conn)
         row = conn.execute(select(project_table)).mappings().first()
     if not row:
         return None
+    _require_created_at(row)
     return {
         "id": row["id"],
         "name": row["name"],

--- a/backend/src/layered_span_studio_backend/repositories/projects.py
+++ b/backend/src/layered_span_studio_backend/repositories/projects.py
@@ -1,21 +1,17 @@
 from __future__ import annotations
 
 import shutil
-import time
 import uuid
 from datetime import datetime, timezone
-from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import func, select
-from sqlalchemy.exc import OperationalError
 
 from layered_span_studio_backend.core.config import Settings
 from layered_span_studio_backend.repositories.label_sync import load_label_rows, sync_labels
 from layered_span_studio_backend.storage.project_db import (
     documents_table,
-    ensure_project_indexes,
     get_project_engine,
     init_project_db,
     labels_table,
@@ -25,7 +21,6 @@ from layered_span_studio_backend.utils.json_utils import decode_meta, encode_met
 
 
 PROJECT_DB_FILENAME = "database.db"
-PROJECT_SCHEMA_RETRY_DELAYS = (0.01, 0.05, 0.1)
 
 
 def _project_dir(settings: Settings, project_id: str) -> Path:
@@ -52,50 +47,6 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
-def _timestamp_to_utc_iso(timestamp: float) -> str:
-    return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def _project_db_timestamp(db_path: Path) -> str:
-    return _timestamp_to_utc_iso(db_path.stat().st_mtime)
-
-
-def _is_sqlite_lock_error(exc: OperationalError) -> bool:
-    message = str(exc).lower()
-    return "database is locked" in message or "database table is locked" in message
-
-
-def _ensure_project_created_at_column(conn, db_path: Path) -> None:
-    for attempt in range(len(PROJECT_SCHEMA_RETRY_DELAYS) + 1):
-        columns = {row["name"] for row in conn.exec_driver_sql("PRAGMA table_info(project)").mappings()}
-        created_at = _project_db_timestamp(db_path)
-        should_backfill = False
-        try:
-            if "created_at" not in columns:
-                should_backfill = True
-                try:
-                    conn.exec_driver_sql("ALTER TABLE project ADD COLUMN created_at TEXT")
-                except OperationalError as exc:
-                    if "duplicate column name" not in str(exc).lower():
-                        raise
-            if not should_backfill:
-                should_backfill = (
-                    conn.execute(select(project_table.c.id).where(project_table.c.created_at.is_(None)).limit(1)).first()
-                    is not None
-                )
-            if should_backfill:
-                conn.execute(
-                    project_table.update()
-                    .where(project_table.c.created_at.is_(None))
-                    .values(created_at=created_at)
-                )
-            return
-        except OperationalError as exc:
-            if attempt == len(PROJECT_SCHEMA_RETRY_DELAYS) or not _is_sqlite_lock_error(exc):
-                raise
-            time.sleep(PROJECT_SCHEMA_RETRY_DELAYS[attempt])
-
-
 def _project_sort_key(project: Dict[str, Any]) -> tuple[Any, ...]:
     summary = project["summary"]
     updated_at_timestamp = _parse_timestamp(summary["updated_at"])
@@ -119,7 +70,6 @@ def list_projects(settings: Settings) -> List[Dict[str, Any]]:
             continue
         engine = get_project_engine(str(db_path))
         with engine.begin() as conn:
-            _ensure_project_created_at_column(conn, db_path)
             row = conn.execute(select(project_table)).mappings().first()
             if not row:
                 continue
@@ -150,30 +100,12 @@ def list_projects(settings: Settings) -> List[Dict[str, Any]]:
     return projects
 
 
-def _ensure_project_indexes_with_retry(db_path: Path) -> None:
-    engine = get_project_engine(str(db_path))
-    for attempt in range(len(PROJECT_SCHEMA_RETRY_DELAYS) + 1):
-        try:
-            ensure_project_indexes(engine)
-            return
-        except OperationalError as exc:
-            if attempt == len(PROJECT_SCHEMA_RETRY_DELAYS) or not _is_sqlite_lock_error(exc):
-                raise
-            time.sleep(PROJECT_SCHEMA_RETRY_DELAYS[attempt])
-
-
-@lru_cache
-def _ensure_project_indexes_once(db_path: str) -> None:
-    _ensure_project_indexes_with_retry(Path(db_path))
-
-
 def get_project(settings: Settings, project_id: str) -> Optional[Dict[str, Any]]:
     db_path = _project_db_path(settings, project_id)
     if not db_path.exists():
         return None
     engine = get_project_engine(str(db_path))
     with engine.begin() as conn:
-        _ensure_project_created_at_column(conn, db_path)
         row = conn.execute(select(project_table)).mappings().first()
     if not row:
         return None
@@ -337,7 +269,4 @@ def delete_project(settings: Settings, project_id: str) -> bool:
 
 
 def project_db_path(settings: Settings, project_id: str) -> Path:
-    db_path = _project_db_path(settings, project_id)
-    if db_path.exists():
-        _ensure_project_indexes_once(str(db_path))
-    return db_path
+    return _project_db_path(settings, project_id)

--- a/backend/src/layered_span_studio_backend/storage/project_db.py
+++ b/backend/src/layered_span_studio_backend/storage/project_db.py
@@ -88,17 +88,23 @@ Index("idx_annotations_document", annotations_table.c.document_id)
 Index("idx_annotations_label", annotations_table.c.label_id)
 Index("idx_annotations_status", annotations_table.c.status)
 Index("idx_annotations_position", annotations_table.c.document_id, annotations_table.c.start, annotations_table.c.end)
-RELATED_EXAMPLE_INDEX_COLUMNS = (
-    ("idx_annotations_surface_search", ("span_text", "status", "document_id", "label_id", "start", "id")),
-    ("idx_annotations_label_surface_groups", ("label_id", "status", "span_text", "document_id", "start", "id")),
+Index(
+    "idx_annotations_surface_search",
+    annotations_table.c.span_text,
+    annotations_table.c.status,
+    annotations_table.c.document_id,
+    annotations_table.c.label_id,
+    annotations_table.c.start,
+    annotations_table.c.id,
 )
-
-for index_name, column_names in RELATED_EXAMPLE_INDEX_COLUMNS:
-    Index(index_name, *(annotations_table.c[column_name] for column_name in column_names))
-
-PROJECT_INDEX_DDL = tuple(
-    f"CREATE INDEX IF NOT EXISTS {index_name} ON annotations ({', '.join(column_names)})"
-    for index_name, column_names in RELATED_EXAMPLE_INDEX_COLUMNS
+Index(
+    "idx_annotations_label_surface_groups",
+    annotations_table.c.label_id,
+    annotations_table.c.status,
+    annotations_table.c.span_text,
+    annotations_table.c.document_id,
+    annotations_table.c.start,
+    annotations_table.c.id,
 )
 
 
@@ -128,17 +134,3 @@ def init_project_db(db_path: Path) -> None:
     db_path.parent.mkdir(parents=True, exist_ok=True)
     engine = _engine_for_path(db_path)
     metadata.create_all(engine)
-    ensure_project_indexes(engine)
-
-
-def ensure_project_indexes(engine: Engine) -> None:
-    with engine.begin() as conn:
-        has_annotations_table = (
-            conn.exec_driver_sql("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'annotations'")
-            .first()
-            is not None
-        )
-        if not has_annotations_table:
-            return
-        for ddl in PROJECT_INDEX_DDL:
-            conn.exec_driver_sql(ddl)

--- a/backend/tests/test_project_schema.py
+++ b/backend/tests/test_project_schema.py
@@ -2,12 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-from sqlalchemy.exc import OperationalError
-
-from layered_span_studio_backend.core.config import Settings
-from layered_span_studio_backend.main import create_app
-from layered_span_studio_backend.repositories import projects as projects_repo
 from layered_span_studio_backend.storage.project_db import get_project_engine, init_project_db
 
 
@@ -53,71 +47,3 @@ def test_related_example_indexes_keep_expected_column_order(tmp_path: Path) -> N
         index_name: _annotation_index_columns(db_path, index_name)
         for index_name in RELATED_EXAMPLE_INDEX_COLUMNS
     } == RELATED_EXAMPLE_INDEX_COLUMNS
-
-
-def test_project_db_path_migrates_existing_project_related_example_indexes(settings: Settings) -> None:
-    project = projects_repo.create_project(settings, "Existing Project", "desc", {})
-    db_path = projects_repo.project_db_path(settings, project["id"])
-    engine = get_project_engine(str(db_path))
-    with engine.begin() as conn:
-        for index_name in RELATED_EXAMPLE_INDEXES:
-            conn.exec_driver_sql(f"DROP INDEX IF EXISTS {index_name}")
-    projects_repo._ensure_project_indexes_once.cache_clear()
-
-    projects_repo.project_db_path(settings, project["id"])
-
-    assert RELATED_EXAMPLE_INDEXES <= _annotation_index_names(db_path)
-
-
-def test_create_app_does_not_block_on_existing_project_index_migration(settings: Settings) -> None:
-    project = projects_repo.create_project(settings, "Startup Project", "desc", {})
-    db_path = projects_repo.project_db_path(settings, project["id"])
-    engine = get_project_engine(str(db_path))
-    with engine.begin() as conn:
-        for index_name in RELATED_EXAMPLE_INDEXES:
-            conn.exec_driver_sql(f"DROP INDEX IF EXISTS {index_name}")
-    projects_repo._ensure_project_indexes_once.cache_clear()
-
-    create_app(settings)
-
-    assert not RELATED_EXAMPLE_INDEXES <= _annotation_index_names(db_path)
-
-
-def test_project_db_path_retries_related_example_index_migration(
-    settings: Settings, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    project = projects_repo.create_project(settings, "Retry Project", "desc", {})
-    db_path = projects_repo.project_db_path(settings, project["id"])
-    projects_repo._ensure_project_indexes_once.cache_clear()
-    attempts = 0
-    real_ensure_project_indexes = projects_repo.ensure_project_indexes
-
-    def flaky_ensure_project_indexes(engine) -> None:
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
-            raise OperationalError("CREATE INDEX", {}, Exception("database is locked"))
-        real_ensure_project_indexes(engine)
-
-    monkeypatch.setattr(projects_repo, "ensure_project_indexes", flaky_ensure_project_indexes)
-
-    projects_repo.project_db_path(settings, project["id"])
-
-    assert attempts == 2
-
-
-def test_project_db_path_skips_related_example_indexes_when_annotations_table_is_missing(
-    settings: Settings,
-) -> None:
-    project_id = "legacy-project-without-annotations"
-    db_path = settings.projects_dir / project_id / "database.db"
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    engine = get_project_engine(str(db_path))
-    with engine.begin() as conn:
-        conn.exec_driver_sql(
-            "CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, meta TEXT, created_at TEXT NOT NULL)"
-        )
-
-    projects_repo._ensure_project_indexes_once.cache_clear()
-
-    assert projects_repo.project_db_path(settings, project_id) == db_path

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import sqlite3
 from datetime import datetime
 
 from fastapi.testclient import TestClient
 
 from conftest import create_label_via_sync
-from layered_span_studio_backend.repositories.projects import _parse_timestamp
+from layered_span_studio_backend.repositories.projects import PROJECT_DB_FILENAME, PROJECT_DB_MIGRATION_MESSAGE, _parse_timestamp
 
 
 def test_project_crud(client: TestClient, auth_headers: dict[str, str]) -> None:
@@ -401,3 +402,59 @@ def test_projects_list_is_sorted_by_pending_then_updated_then_name(client: TestC
 def test_project_timestamp_parser_rejects_naive_datetime() -> None:
     assert _parse_timestamp("2026-03-01T00:00:00") is None
     assert _parse_timestamp("2026-03-01T00:00:00Z") is not None
+
+
+def test_projects_list_reports_unmigrated_project_db(settings, client: TestClient, auth_headers: dict[str, str]) -> None:
+    project_id = "unmigrated-project"
+    project_dir = settings.projects_dir / project_id
+    project_dir.mkdir(parents=True, exist_ok=True)
+    db_path = project_dir / PROJECT_DB_FILENAME
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, meta TEXT)")
+        conn.execute(
+            "CREATE TABLE labels (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, name TEXT NOT NULL, color TEXT NOT NULL, description TEXT NOT NULL, shortcut TEXT, meta TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE documents (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, document_name TEXT NOT NULL, text TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'pending', created_at TEXT NOT NULL, updated_at TEXT NOT NULL, meta TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO project (id, name, description, meta) VALUES (?, ?, ?, ?)",
+            (project_id, "Unmigrated Project", "desc", "{}"),
+        )
+
+    response = client.get("/projects", headers=auth_headers)
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == PROJECT_DB_MIGRATION_MESSAGE
+
+
+def test_project_detail_reports_null_created_at_project_db(
+    settings,
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    project_id = "null-created-at-project"
+    project_dir = settings.projects_dir / project_id
+    project_dir.mkdir(parents=True, exist_ok=True)
+    db_path = project_dir / PROJECT_DB_FILENAME
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, meta TEXT, created_at TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE labels (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, name TEXT NOT NULL, color TEXT NOT NULL, description TEXT NOT NULL, shortcut TEXT, meta TEXT, display_order INTEGER)"
+        )
+        conn.execute(
+            "CREATE TABLE documents (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, document_name TEXT NOT NULL, text TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'pending', created_at TEXT NOT NULL, updated_at TEXT NOT NULL, meta TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO project (id, name, description, meta, created_at) VALUES (?, ?, ?, ?, ?)",
+            (project_id, "Null Created At Project", "desc", "{}", None),
+        )
+
+    response = client.get(f"/projects/{project_id}", headers=auth_headers)
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == PROJECT_DB_MIGRATION_MESSAGE

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import os
-import sqlite3
-from datetime import datetime, timezone
+from datetime import datetime
 
 from fastapi.testclient import TestClient
 
 from conftest import create_label_via_sync
-from layered_span_studio_backend.repositories.projects import PROJECT_DB_FILENAME, _parse_timestamp
+from layered_span_studio_backend.repositories.projects import _parse_timestamp
 
 
 def test_project_crud(client: TestClient, auth_headers: dict[str, str]) -> None:
@@ -403,121 +401,3 @@ def test_projects_list_is_sorted_by_pending_then_updated_then_name(client: TestC
 def test_project_timestamp_parser_rejects_naive_datetime() -> None:
     assert _parse_timestamp("2026-03-01T00:00:00") is None
     assert _parse_timestamp("2026-03-01T00:00:00Z") is not None
-
-
-def test_projects_list_backfills_created_at_from_legacy_project_db(
-    client: TestClient,
-    auth_headers: dict[str, str],
-    settings,
-) -> None:
-    project_id = "legacy-project"
-    project_dir = settings.projects_dir / project_id
-    project_dir.mkdir(parents=True, exist_ok=True)
-    db_path = project_dir / PROJECT_DB_FILENAME
-
-    with sqlite3.connect(db_path) as conn:
-        conn.execute("CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, meta TEXT)")
-        conn.execute(
-            "CREATE TABLE labels (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, name TEXT NOT NULL, color TEXT NOT NULL, description TEXT NOT NULL, shortcut TEXT, meta TEXT)"
-        )
-        conn.execute(
-            "CREATE TABLE documents (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, document_name TEXT NOT NULL, text TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'pending', created_at TEXT NOT NULL, updated_at TEXT NOT NULL, meta TEXT)"
-        )
-        conn.execute(
-            "INSERT INTO project (id, name, description, meta) VALUES (?, ?, ?, ?)",
-            (project_id, "Legacy Project", "desc", "{}"),
-        )
-        conn.commit()
-    legacy_timestamp = datetime(2026, 3, 7, 12, 34, 56, tzinfo=timezone.utc).timestamp()
-    os.utime(db_path, (legacy_timestamp, legacy_timestamp))
-    expected_created_at = datetime.fromtimestamp(db_path.stat().st_mtime, tz=timezone.utc).isoformat().replace("+00:00", "Z")
-
-    response = client.get("/projects", headers=auth_headers)
-    assert response.status_code == 200
-    payload = next(item for item in response.json()["projects"] if item["id"] == project_id)
-    assert payload["created_at"] == expected_created_at
-
-    with sqlite3.connect(db_path) as conn:
-        columns = {row[1] for row in conn.execute("PRAGMA table_info(project)")}
-        assert "created_at" in columns
-        stored_created_at = conn.execute("SELECT created_at FROM project WHERE id = ?", (project_id,)).fetchone()[0]
-    assert stored_created_at == expected_created_at
-
-
-def test_labels_api_backfills_display_order_from_legacy_project_db(
-    client: TestClient,
-    auth_headers: dict[str, str],
-    settings,
-) -> None:
-    project_id = "legacy-label-order-project"
-    project_dir = settings.projects_dir / project_id
-    project_dir.mkdir(parents=True, exist_ok=True)
-    db_path = project_dir / PROJECT_DB_FILENAME
-
-    with sqlite3.connect(db_path) as conn:
-        conn.execute(
-            "CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, meta TEXT, created_at TEXT NOT NULL)"
-        )
-        conn.execute(
-            "CREATE TABLE labels (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, name TEXT NOT NULL, color TEXT NOT NULL, description TEXT NOT NULL, shortcut TEXT, meta TEXT)"
-        )
-        conn.execute(
-            "CREATE TABLE documents (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, document_name TEXT NOT NULL, text TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'pending', created_at TEXT NOT NULL, updated_at TEXT NOT NULL, meta TEXT)"
-        )
-        conn.execute(
-            "INSERT INTO project (id, name, description, meta, created_at) VALUES (?, ?, ?, ?, ?)",
-            (project_id, "Legacy Label Order Project", "desc", "{}", "2026-03-01T00:00:00Z"),
-        )
-        conn.executemany(
-            "INSERT INTO labels (id, project_id, name, color, description, shortcut, meta) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            [
-                ("label-z", project_id, "Zulu", "#FF5733", "desc", None, "{}"),
-                ("label-a", project_id, "Alpha", "#33AA44", "desc", None, "{}"),
-            ],
-        )
-        conn.commit()
-
-    response = client.get(f"/projects/{project_id}/labels", headers=auth_headers)
-    assert response.status_code == 200
-    assert [label["name"] for label in response.json()["labels"]] == ["Alpha", "Zulu"]
-
-    with sqlite3.connect(db_path) as conn:
-        columns = {row[1] for row in conn.execute("PRAGMA table_info(labels)")}
-        stored_order = conn.execute("SELECT name, display_order FROM labels ORDER BY display_order").fetchall()
-    assert "display_order" in columns
-    assert stored_order == [("Alpha", 0), ("Zulu", 1)]
-
-
-def test_projects_list_backfills_null_created_at_when_column_already_exists(
-    client: TestClient,
-    auth_headers: dict[str, str],
-    settings,
-) -> None:
-    project_id = "legacy-null-project"
-    project_dir = settings.projects_dir / project_id
-    project_dir.mkdir(parents=True, exist_ok=True)
-    db_path = project_dir / PROJECT_DB_FILENAME
-
-    with sqlite3.connect(db_path) as conn:
-        conn.execute(
-            "CREATE TABLE project (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, meta TEXT, created_at TEXT)"
-        )
-        conn.execute(
-            "CREATE TABLE labels (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, name TEXT NOT NULL, color TEXT NOT NULL, description TEXT NOT NULL, shortcut TEXT, meta TEXT)"
-        )
-        conn.execute(
-            "CREATE TABLE documents (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, document_name TEXT NOT NULL, text TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'pending', created_at TEXT NOT NULL, updated_at TEXT NOT NULL, meta TEXT)"
-        )
-        conn.execute(
-            "INSERT INTO project (id, name, description, meta, created_at) VALUES (?, ?, ?, ?, ?)",
-            (project_id, "Legacy Null Project", "desc", "{}", None),
-        )
-        conn.commit()
-    legacy_timestamp = datetime(2026, 3, 8, 9, 10, 11, tzinfo=timezone.utc).timestamp()
-    os.utime(db_path, (legacy_timestamp, legacy_timestamp))
-    expected_created_at = datetime.fromtimestamp(db_path.stat().st_mtime, tz=timezone.utc).isoformat().replace("+00:00", "Z")
-
-    response = client.get("/projects", headers=auth_headers)
-    assert response.status_code == 200
-    payload = next(item for item in response.json()["projects"] if item["id"] == project_id)
-    assert payload["created_at"] == expected_created_at

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -247,7 +247,7 @@ Authorization: Bearer <token>
 ```
 
 **注記:**
-- `created_at`: project 作成時刻。既存 project は `database.db` のファイル時刻で補完する
+- `created_at`: project 作成時刻。backend が project 作成時に UTC ISO 8601 で保存する
 - `summary.labels_count`: project 配下 label の総数
 - `summary.documents_count`: project 配下 document の総数
 - `summary.pending_documents_count`: `document.status != verified` の document 総数

--- a/docs/backend/database-schema.md
+++ b/docs/backend/database-schema.md
@@ -163,9 +163,6 @@ CREATE TABLE project (
 | meta | TEXT | NULL | 任意の拡張情報（JSON文字列） |
 | created_at | TEXT | NOT NULL | プロジェクト作成日時（ISO 8601 UTC） |
 
-メモ:
-- 既存 project DB に `created_at` が無い場合は、初回アクセス時に `database.db` のファイル時刻を使って補完する
-
 ---
 
 ### labels テーブル
@@ -602,7 +599,7 @@ UUID形式のIDを使用しているため、ID衝突の心配なくインポー
 
 補足:
 - `span_text` 単独ではなく、関連例 API の主要条件に合わせた composite index を使います。これにより同一表層検索と label surface group の query plan が annotation 全体走査に寄りにくくなります。
-- 既存 project DB は project DB 初回アクセス時に `CREATE INDEX IF NOT EXISTS` で移行されます。SQLite lock が一時的に発生した場合は短い retry を行います。
+- 既存 project DB は明示的な migration 操作でこの index を作成済みとして扱います。アプリケーションコードは既存 DB の自動変換を行いません。
 - `surface-groups` や `annotations/search` は SQL 側で絞り込み・集約・ページングを行います。total count も同じ composite index を利用する前提です。
 
 ### スケーラビリティ

--- a/docs/backend/json-schema.md
+++ b/docs/backend/json-schema.md
@@ -221,7 +221,7 @@ response 例:
 ```
 
 - response の `projects` は一覧用の `summary` を持つ
-- `created_at`: project 作成時刻。既存 project は `database.db` のファイル時刻で補完する
+- `created_at`: project 作成時刻。backend が project 作成時に UTC ISO 8601 で保存する
 - `summary.labels_count`: project 配下 label の総数
 - `summary.documents_count`: project 配下 document の総数
 - `summary.pending_documents_count`: `document.status != "verified"` の document 総数


### PR DESCRIPTION
## 概要
- 既存 project DB を自動変換するアプリコードを削除
- 関連例 index の lazy migration / retry ロジックを削除
- `project.created_at` と `labels.display_order` の legacy backfill を削除
- 新規 project は引き続き `project_db.py` の SQLAlchemy metadata から最新 schema/index を作成
- docs から旧 backfill 説明を削除し、既存 DB は明示 migration 済みとして扱う方針に更新

## 明示 migration 操作
- ローカルの既存 `backend/data/projects/*/database.db` に対して、`created_at` / `display_order` / 関連例 index の作成・補完を実行済み
- migration 操作用スクリプトやコマンドは管理対象外のため commit していない

## 確認
- `cd backend && uv run pytest`（113 passed）
- `cd frontend && npm run test`（179 passed）
- `cd frontend && npm run build`

## セルフレビュー
- subagent セルフレビューを2回実施
- 初回指摘の docs 旧 backfill 記述を修正
- 再レビューで指摘なし