### PR TITLE
fix(frontend): submit後の次Document遷移を安定化

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -86,6 +86,7 @@ export function ProjectShell({
   const { t } = useI18n();
   const { toast, showToast, closeToast } = useToast();
   const [saving, setSaving] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
   const [focusedLabelId, setFocusedLabelId] = useState<string | null>(null);
   const [selectedSettingsLabelId, setSelectedSettingsLabelId] = useState<string | null>(null);
@@ -166,7 +167,7 @@ export function ProjectShell({
   }, [bundle, selectedDocId]);
   const currentDocumentLoading = Boolean(selectedDocId && !currentDocument);
   const currentDocumentSnapshot = currentDocument ? documentSnapshotsById[currentDocument.id] ?? null : null;
-  const workspaceBusy = saving || deletingDocument;
+  const workspaceBusy = saving || submitting || deletingDocument;
 
   const {
     historyState,
@@ -771,26 +772,31 @@ export function ProjectShell({
     if (!bundle || !currentDocument || view !== "workspace" || workspaceBusy) {
       return;
     }
-    const savedDocument = await saveCurrentDocument(null, true);
-    if (!savedDocument) {
-      return;
-    }
-    const refreshedDocuments = await fetchDocumentPage(true, savedDocument.id);
-    const currentIndex = refreshedDocuments.findIndex((document) => document.id === savedDocument.id);
-    const forwardPending =
-      currentIndex >= 0
-        ? refreshedDocuments.slice(currentIndex + 1).find((document) => getDocumentStatus(document) === "pending")
-        : null;
-    const fallbackPending = refreshedDocuments.find((document) => getDocumentStatus(document) === "pending") ?? null;
-    const nextId = forwardPending?.id ?? fallbackPending?.id ?? null;
-    if (nextId) {
-      const loaded = await preloadDocumentForActivation(nextId);
-      if (!loaded) {
+    setSubmitting(true);
+    try {
+      const savedDocument = await saveCurrentDocument(null, true);
+      if (!savedDocument) {
         return;
       }
-      activateDocument(nextId);
+      const refreshedDocuments = await fetchDocumentPage(true, savedDocument.id);
+      const currentIndex = refreshedDocuments.findIndex((document) => document.id === savedDocument.id);
+      const forwardPending =
+        currentIndex >= 0
+          ? refreshedDocuments.slice(currentIndex + 1).find((document) => getDocumentStatus(document) === "pending")
+          : null;
+      const fallbackPending = refreshedDocuments.find((document) => getDocumentStatus(document) === "pending") ?? null;
+      const nextId = forwardPending?.id ?? fallbackPending?.id ?? null;
+      if (nextId) {
+        const loaded = await preloadDocumentForActivation(nextId);
+        if (!loaded) {
+          return;
+        }
+        activateDocument(nextId);
+      }
+      showToast(t("projectShell.toasts.submitted"), "success");
+    } finally {
+      setSubmitting(false);
     }
-    showToast(t("projectShell.toasts.submitted"), "success");
   }
 
   function executePendingAction(action: PendingAction) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -319,6 +319,34 @@ export function ProjectShell({
     resetWorkspacePanels();
   }
 
+  async function preloadDocumentForActivation(documentId: string) {
+    if (!bundle) {
+      return false;
+    }
+    if (bundle.documents.some((document) => document.id === documentId)) {
+      return true;
+    }
+    try {
+      const document = await api.getDocument(bundle.project.id, documentId);
+      setBundle((current) =>
+        current
+          ? {
+              ...current,
+              documents: [...current.documents.filter((item) => item.id !== document.id), document],
+            }
+          : current,
+      );
+      setDocumentSnapshotsById((current) => ({
+        ...current,
+        [document.id]: deepClone(document),
+      }));
+      return true;
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : "Document の取得に失敗した", "error");
+      return false;
+    }
+  }
+
   function handleShortcutDragStart(event: React.PointerEvent<HTMLDivElement>) {
     shortcutDragStateRef.current = {
       startX: event.clientX,
@@ -756,6 +784,10 @@ export function ProjectShell({
     const fallbackPending = refreshedDocuments.find((document) => getDocumentStatus(document) === "pending") ?? null;
     const nextId = forwardPending?.id ?? fallbackPending?.id ?? null;
     if (nextId) {
+      const loaded = await preloadDocumentForActivation(nextId);
+      if (!loaded) {
+        return;
+      }
       activateDocument(nextId);
     }
     showToast(t("projectShell.toasts.submitted"), "success");

--- a/frontend/src/test/projectShellSubmit.test.tsx
+++ b/frontend/src/test/projectShellSubmit.test.tsx
@@ -377,6 +377,8 @@ describe("ProjectShell submit behavior", () => {
       expect(getDocumentSpy).toHaveBeenCalledWith("project-1", "doc-2");
     });
     expect(getDocumentRow("Doc 2")).not.toHaveClass("Mui-selected");
+    await userEventSetup.click(screen.getByRole("button", { name: "Submit" }));
+    expect(saveDocumentBundleSpy).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       secondDocumentLoad.resolve(secondDocument);

--- a/frontend/src/test/projectShellSubmit.test.tsx
+++ b/frontend/src/test/projectShellSubmit.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { setupUserEvent } from "./userEvent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ProjectShell } from "../App";
@@ -225,6 +225,20 @@ function createAnnotation(overrides: Partial<AnnotationRecord> = {}): Annotation
   };
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function toDocumentListStub(document: DocumentRecord): Omit<DocumentRecord, "annotations"> {
+  return { ...document, annotations: undefined } as Omit<DocumentRecord, "annotations">;
+}
+
 function getDocumentRow(documentName: string) {
   const row = screen
     .getAllByText(documentName)
@@ -293,6 +307,90 @@ describe("ProjectShell submit behavior", () => {
       expect(saveDocumentBundleSpy).toHaveBeenCalledWith("project-1", "doc-1", [], true);
     });
     expect(await screen.findByText("0 pending / 1 docs")).toBeInTheDocument();
+  });
+
+  it("loads the next pending document before focusing it after submit", async () => {
+    const userEventSetup = setupUserEvent();
+    const firstDocument = createDocument();
+    const secondDocument = createDocument({
+      id: "doc-2",
+      document_name: "Doc 2",
+      text: "Second document",
+      created_at: "2026-03-02T00:00:00Z",
+      updated_at: "2026-03-02T00:00:00Z",
+    });
+    const verifiedFirstDocument = createDocument({
+      status: "verified",
+      updated_at: "2026-03-03T00:00:00Z",
+    });
+    const verifiedSecondDocument = createDocument({
+      ...secondDocument,
+      status: "verified",
+      updated_at: "2026-03-04T00:00:00Z",
+    });
+    const secondDocumentLoad = createDeferred<DocumentRecord>();
+
+    vi.spyOn(api, "listDocuments")
+      .mockResolvedValueOnce({
+        documents: [firstDocument, secondDocument].map(toDocumentListStub),
+        total: 2,
+        pending_total: 2,
+        offset: 0,
+        limit: 40,
+        search: "",
+        sort: "created",
+      })
+      .mockResolvedValueOnce({
+        documents: [verifiedFirstDocument, secondDocument].map(toDocumentListStub),
+        total: 2,
+        pending_total: 1,
+        offset: 0,
+        limit: 40,
+        search: "",
+        sort: "created",
+      })
+      .mockResolvedValueOnce({
+        documents: [verifiedFirstDocument, verifiedSecondDocument].map(toDocumentListStub),
+        total: 2,
+        pending_total: 0,
+        offset: 0,
+        limit: 40,
+        search: "",
+        sort: "created",
+      });
+    const getDocumentSpy = vi.spyOn(api, "getDocument").mockImplementation((_projectId, documentId) => {
+      if (documentId === "doc-2") {
+        return secondDocumentLoad.promise;
+      }
+      return Promise.resolve(firstDocument);
+    });
+    const saveDocumentBundleSpy = vi.spyOn(api, "saveDocumentBundle").mockImplementation((_projectId, documentId) => {
+      return Promise.resolve(documentId === "doc-2" ? verifiedSecondDocument : verifiedFirstDocument);
+    });
+
+    renderWorkspace();
+
+    await screen.findByText("2 pending / 2 docs");
+    await userEventSetup.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(getDocumentSpy).toHaveBeenCalledWith("project-1", "doc-2");
+    });
+    expect(getDocumentRow("Doc 2")).not.toHaveClass("Mui-selected");
+
+    await act(async () => {
+      secondDocumentLoad.resolve(secondDocument);
+      await secondDocumentLoad.promise;
+    });
+    await waitFor(() => {
+      expect(getDocumentRow("Doc 2")).toHaveClass("Mui-selected");
+    });
+
+    await userEventSetup.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(saveDocumentBundleSpy).toHaveBeenCalledWith("project-1", "doc-2", [], true);
+    });
   });
 
   it("saves edited annotations without submit flag", async () => {


### PR DESCRIPTION
## Summary
- submit後に次のpending Documentを選択する前に詳細データを読み込み、選択表示と`currentDocument`の不整合を防ぐ
- 次Documentの詳細ロード前にはfocusを進めない回帰テストを追加し、連続submitで次Documentがverified化されることを確認する

## Test plan
- `npm test -- --run`
- `npm run build`